### PR TITLE
feat: restore station workflow with realtime scanning

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,159 +1,305 @@
 :root {
-  color-scheme: light;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f5f5f5;
-  color: #1f2933;
+  color-scheme: only light;
+  font-family: 'Inter', 'SF Pro Display', 'Segoe UI', system-ui, sans-serif;
+  background: #f4efe6;
+  color: #2f2a25;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  background: #f5f5f5;
+  background: #f4efe6;
 }
 
 .app-shell {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background: linear-gradient(180deg, #f4efe6 0%, #f7f2eb 32%, #fefcf8 100%);
 }
 
-.topbar {
-  padding: 16px 24px;
-  background: #1f2933;
-  color: #fff;
+.hero {
+  padding: 56px 24px 96px;
+  background: linear-gradient(160deg, #0d7c54 0%, #0b5d44 60%, #0a4e38 100%);
+  color: #fffdf7;
+}
+
+.hero-brand {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.hero-logo {
+  width: 88px;
+  height: 88px;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.12);
+  display: grid;
+  place-items: center;
+  font-size: 42px;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: 32px;
+  letter-spacing: 0.02em;
+}
+
+.hero p {
+  margin: 8px 0 0;
+  max-width: 420px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.84);
+}
+
+.hero-meta {
+  margin-top: 28px;
+  display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 12px;
 }
 
-.topbar code {
-  background: rgba(255, 255, 255, 0.1);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 12px;
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.16);
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.meta-pill.subtle {
+  background: rgba(15, 118, 110, 0.22);
+  color: #e0fbf4;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 0 24px 64px;
+  max-width: 960px;
+  width: 100%;
+  margin: -72px auto 0;
 }
 
 .alerts {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 12px;
 }
 
 .alert {
-  background: #2563eb;
-  color: #fff;
-  padding: 6px 10px;
-  border-radius: 6px;
-  font-size: 14px;
-  box-shadow: 0 6px 14px rgba(37, 99, 235, 0.3);
-}
-
-.layout {
-  display: grid;
-  gap: 16px;
-  padding: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.12), rgba(13, 148, 136, 0.22));
+  color: #0b5346;
+  padding: 12px 16px;
+  border-radius: 18px;
+  font-weight: 600;
+  box-shadow: 0 18px 38px rgba(13, 148, 136, 0.18);
 }
 
 .card {
-  background: #fff;
-  border-radius: 14px;
-  padding: 18px;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  background: #ffffff;
+  border-radius: 28px;
+  box-shadow: 0 28px 60px rgba(17, 24, 39, 0.12);
+  padding: 32px 28px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 20px;
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
 }
 
-.card h2 {
+.card-header h2 {
   margin: 0;
+}
+
+.card-subtitle {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: #7d6d60;
+}
+
+.card-hint {
+  font-size: 14px;
+  color: #988c82;
 }
 
 button {
   cursor: pointer;
-  background: #2563eb;
-  color: #fff;
   border: none;
-  border-radius: 8px;
-  padding: 8px 14px;
-  font-weight: 600;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  border-radius: 18px;
+  padding: 14px 22px;
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
 }
 
-button:hover {
+button.primary {
+  background: linear-gradient(135deg, #f59e0b 0%, #f97316 100%);
+  color: #fff9ed;
+  box-shadow: 0 16px 28px rgba(249, 115, 22, 0.25);
+}
+
+button.primary:hover {
   transform: translateY(-1px);
-  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.25);
+  box-shadow: 0 20px 34px rgba(249, 115, 22, 0.35);
+}
+
+button.ghost {
+  background: rgba(15, 118, 110, 0.08);
+  color: #0f766e;
+}
+
+button.ghost:hover {
+  background: rgba(15, 118, 110, 0.16);
 }
 
 button:disabled {
-  background: #94a3b8;
+  opacity: 0.6;
   cursor: not-allowed;
   box-shadow: none;
-}
-
-button.secondary {
-  background: #e2e8f0;
-  color: #1f2933;
+  transform: none;
 }
 
 label {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
   font-size: 14px;
   font-weight: 600;
+  color: #3f3025;
 }
 
 input,
 textarea {
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 8px;
-  font-size: 14px;
+  width: 100%;
+  border: 1px solid #e2d9cd;
+  border-radius: 16px;
+  padding: 12px 14px;
+  font-size: 15px;
   font-family: inherit;
+  background: #fffdf9;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: #0d7c54;
+  box-shadow: 0 0 0 4px rgba(13, 124, 84, 0.12);
 }
 
 textarea {
   resize: vertical;
+  min-height: 110px;
+}
+
+.answers-card {
+  gap: 16px;
+}
+
+.answers-summary {
+  display: grid;
+  gap: 12px;
+}
+
+.answers-summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f3f6ff;
+  color: #1e3a8a;
+  padding: 12px 16px;
+  border-radius: 18px;
+}
+
+.answers-tag {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.answers-value {
+  font-size: 14px;
+}
+
+.answers-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .answers-grid {
   display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
 .answers-field span {
-  font-size: 12px;
-  color: #475569;
+  font-size: 13px;
+  color: #6b5c50;
 }
 
-.switch-field {
-  flex-direction: row;
-  align-items: center;
-  gap: 8px;
-  font-weight: 500;
+.answers-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.scanner-card {
+  gap: 18px;
+}
+
+.scanner-icon {
+  width: 92px;
+  height: 92px;
+  border-radius: 26px;
+  background: #fff4e5;
+  color: #d97706;
+  display: grid;
+  place-items: center;
+  font-size: 40px;
+}
+
+.scanner-copy h2 {
+  margin: 0;
+}
+
+.scanner-copy p {
+  margin: 6px 0 0;
+  color: #6b5c50;
 }
 
 .scanner-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
 .qr-scanner {
   position: relative;
   aspect-ratio: 4 / 3;
   background: #0f172a;
-  border-radius: 12px;
+  border-radius: 16px;
   overflow: hidden;
 }
 
@@ -170,25 +316,46 @@ textarea {
   right: 8px;
   background: rgba(220, 38, 38, 0.9);
   color: #fff;
-  padding: 6px;
-  border-radius: 6px;
+  padding: 6px 10px;
+  border-radius: 10px;
   font-size: 12px;
 }
 
 .manual-entry {
   display: flex;
-  gap: 12px;
+  gap: 16px;
   align-items: flex-end;
+  flex-wrap: wrap;
 }
 
 .manual-entry input {
-  min-width: 180px;
+  min-width: 200px;
+}
+
+.scanner-preview {
+  padding: 12px 18px;
+  border-radius: 16px;
+  background: #f1f5f9;
+  color: #1f2937;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 15px;
+}
+
+.scanner-placeholder {
+  font-style: italic;
+  color: #9c8d82;
+}
+
+.form-card {
+  gap: 18px;
 }
 
 .form-grid {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 18px;
 }
 
 .patrol-meta {
@@ -197,15 +364,49 @@ textarea {
   gap: 4px;
 }
 
+.switch-field {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.switch-field input {
+  width: auto;
+  accent-color: #0d7c54;
+}
+
+.auto-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.auto-score {
+  font-weight: 600;
+}
+
+.error-text {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.form-placeholder {
+  font-style: italic;
+  color: #7d6d60;
+}
+
 .pending-banner {
-  margin-top: 12px;
-  padding: 10px;
-  border-radius: 10px;
+  margin-top: 4px;
+  padding: 12px 16px;
+  border-radius: 18px;
   background: #fff7ed;
   border: 1px solid #fdba74;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
+  font-size: 14px;
 }
 
 .score-list {
@@ -214,16 +415,16 @@ textarea {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
 .score-item {
   border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  padding: 12px;
+  border-radius: 16px;
+  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .score-meta {
@@ -231,6 +432,8 @@ textarea {
   justify-content: space-between;
   font-size: 13px;
   color: #64748b;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .score-detail {
@@ -247,23 +450,30 @@ textarea {
   color: #1d4ed8;
 }
 
-.auto-section {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
+@media (max-width: 720px) {
+  .hero {
+    padding: 44px 20px 84px;
+  }
 
-.error-text {
-  color: #dc2626;
-  font-weight: 600;
-}
+  .hero-meta {
+    flex-direction: column;
+    gap: 10px;
+  }
 
-@media (max-width: 640px) {
-  .layout {
-    padding: 16px;
+  .content {
+    padding: 0 18px 48px;
+    margin-top: -64px;
+  }
+
+  button {
+    width: 100%;
   }
 
   .manual-entry {
+    align-items: stretch;
+  }
+
+  .pending-banner {
     flex-direction: column;
     align-items: stretch;
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import localforage from 'localforage';
-import { QRScanner } from './components/QRScanner';
+import QRScanner from './components/QRScanner';
 import LastScoresList from './components/LastScoresList';
 import { supabase } from './supabaseClient';
 import './App.css';
@@ -33,12 +33,15 @@ type CategoryKey = (typeof ANSWER_CATEGORIES)[number];
 const QUEUE_KEY = 'web_pending_station_submissions_v1';
 const JUDGE_KEY = 'judge_name';
 
-const eventId = import.meta.env.VITE_EVENT_ID as string | undefined;
-const stationId = import.meta.env.VITE_STATION_ID as string | undefined;
+const rawEventId = import.meta.env.VITE_EVENT_ID as string | undefined;
+const rawStationId = import.meta.env.VITE_STATION_ID as string | undefined;
 
-if (!eventId || !stationId) {
+if (!rawEventId || !rawStationId) {
   throw new Error('Missing VITE_EVENT_ID or VITE_STATION_ID environment variables.');
 }
+
+const eventId = rawEventId;
+const stationId = rawStationId;
 
 localforage.config({
   name: 'seton-web',
@@ -69,6 +72,10 @@ async function writeQueue(items: PendingSubmission[]) {
   }
 }
 
+function formatTime(value: string) {
+  return new Date(value).toLocaleTimeString('cs-CZ', { hour: '2-digit', minute: '2-digit' });
+}
+
 function App() {
   const [judge, setJudge] = useState('');
   const [patrol, setPatrol] = useState<Patrol | null>(null);
@@ -93,12 +100,14 @@ function App() {
   const [savingAnswers, setSavingAnswers] = useState(false);
   const [autoScore, setAutoScore] = useState({ correct: 0, total: 0, given: 0, normalizedGiven: '' });
   const [alerts, setAlerts] = useState<string[]>([]);
+  const [answersEditorOpen, setAnswersEditorOpen] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
 
   const pushAlert = useCallback((message: string) => {
     setAlerts((prev) => [...prev, message]);
     setTimeout(() => {
       setAlerts((prev) => prev.slice(1));
-    }, 4000);
+    }, 4500);
   }, []);
 
   useEffect(() => {
@@ -127,14 +136,16 @@ function App() {
     }
 
     const map: Record<string, string> = {};
-    const form = { ...answersForm };
+    const form: Record<CategoryKey, string> = { N: '', M: '', S: '', R: '' };
     (data || []).forEach((row) => {
       map[row.category] = row.correct_answers;
-      form[row.category as keyof typeof form] = formatAnswersForInput(row.correct_answers);
+      if (ANSWER_CATEGORIES.includes(row.category as CategoryKey)) {
+        form[row.category as CategoryKey] = formatAnswersForInput(row.correct_answers);
+      }
     });
     setCategoryAnswers(map);
     setAnswersForm(form);
-  }, [answersForm, pushAlert]);
+  }, [pushAlert]);
 
   useEffect(() => {
     loadCategoryAnswers();
@@ -143,8 +154,7 @@ function App() {
   const syncQueue = useCallback(async () => {
     const queue = await readQueue();
     setPendingCount(queue.length);
-    if (!queue.length) return;
-    if (syncing) return;
+    if (!queue.length || syncing) return;
 
     setSyncing(true);
     const remaining: PendingSubmission[] = [];
@@ -225,6 +235,7 @@ function App() {
 
     if (flushed) {
       pushAlert(`Synchronizováno ${flushed} záznamů.`);
+      setLastSavedAt(new Date().toISOString());
     }
   }, [pushAlert, syncing]);
 
@@ -235,7 +246,7 @@ function App() {
     return () => window.removeEventListener('online', onOnline);
   }, [syncQueue]);
 
-  const resetForm = () => {
+  const resetForm = useCallback(() => {
     setPatrol(null);
     setPoints('');
     setWait('0');
@@ -245,43 +256,50 @@ function App() {
     setAutoScore({ correct: 0, total: 0, given: 0, normalizedGiven: '' });
     setUseTargetScoring(false);
     setScanActive(true);
-  };
+  }, []);
 
-  const handleScanResult = async (text: string) => {
-    const match = text.match(/seton:\/\/p\/(.+)$/);
-    if (!match) {
-      pushAlert('Neplatný QR kód. Očekávám seton://p/<code>');
-      return;
-    }
-    await fetchPatrol(match[1]);
-  };
+  const fetchPatrol = useCallback(
+    async (patrolCode: string) => {
+      const { data, error } = await supabase
+        .from('patrols')
+        .select('id, team_name, category, sex')
+        .eq('event_id', eventId)
+        .eq('patrol_code', patrolCode)
+        .maybeSingle();
 
-  const fetchPatrol = useCallback(async (patrolCode: string) => {
-    const { data, error } = await supabase
-      .from('patrols')
-      .select('id, team_name, category, sex')
-      .eq('event_id', eventId)
-      .eq('patrol_code', patrolCode)
-      .maybeSingle();
+      if (error || !data) {
+        pushAlert('Hlídka nenalezena.');
+        return;
+      }
 
-    if (error || !data) {
-      pushAlert('Hlídka nenalezena.');
-      return;
-    }
+      setPatrol({ ...data });
+      setPoints('');
+      setWait('0');
+      setNote('');
+      setAnswersInput('');
+      setAnswersError('');
+      setScanActive(false);
+      setManualCode('');
 
-    setPatrol({ ...data });
-    setPoints('');
-    setWait('0');
-    setNote('');
-    setAnswersInput('');
-    setAnswersError('');
-    setScanActive(false);
+      const stored = categoryAnswers[data.category] || '';
+      const total = parseAnswerLetters(stored).length;
+      setAutoScore({ correct: 0, total, given: 0, normalizedGiven: '' });
+      setUseTargetScoring(Boolean(stored));
+    },
+    [categoryAnswers, pushAlert]
+  );
 
-    const stored = categoryAnswers[data.category] || '';
-    const total = parseAnswerLetters(stored).length;
-    setAutoScore({ correct: 0, total, given: 0, normalizedGiven: '' });
-    setUseTargetScoring(Boolean(stored));
-  }, [categoryAnswers, pushAlert]);
+  const handleScanResult = useCallback(
+    async (text: string) => {
+      const match = text.match(/seton:\/\/p\/(.+)$/);
+      if (!match) {
+        pushAlert('Neplatný QR kód. Očekávám seton://p/<code>');
+        return;
+      }
+      await fetchPatrol(match[1]);
+    },
+    [fetchPatrol, pushAlert]
+  );
 
   useEffect(() => {
     if (!patrol || !useTargetScoring) {
@@ -313,7 +331,7 @@ function App() {
 
   const saveCategoryAnswers = useCallback(async () => {
     setSavingAnswers(true);
-    const updates = [] as { event_id: string; station_id: string; category: string; correct_answers: string }[];
+    const updates: { event_id: string; station_id: string; category: string; correct_answers: string }[] = [];
     const deletions: string[] = [];
 
     for (const cat of ANSWER_CATEGORIES) {
@@ -430,6 +448,7 @@ function App() {
       await writeQueue([...queueBefore, submission]);
       setPendingCount(queueBefore.length + 1);
       pushAlert('Offline: průchod uložen do fronty.');
+      setLastSavedAt(now);
       resetForm();
       return;
     }
@@ -452,6 +471,7 @@ function App() {
       await writeQueue([...queueBefore, submission]);
       setPendingCount(queueBefore.length + 1);
       pushAlert('Offline: body uložené do fronty.');
+      setLastSavedAt(now);
       resetForm();
       return;
     }
@@ -474,6 +494,7 @@ function App() {
         await writeQueue([...queueBefore, submission]);
         setPendingCount(queueBefore.length + 1);
         pushAlert('Offline: odpovědi uložené do fronty.');
+        setLastSavedAt(now);
         resetForm();
         return;
       }
@@ -486,80 +507,172 @@ function App() {
         await writeQueue([...queueBefore, submission]);
         setPendingCount(queueBefore.length + 1);
         pushAlert('Offline: odstranění odpovědí čeká ve frontě.');
+        setLastSavedAt(now);
         resetForm();
         return;
       }
     }
 
     pushAlert(`Uloženo: ${patrol.team_name} (${scorePoints} b)`);
+    setLastSavedAt(now);
     resetForm();
     syncQueue();
-  }, [autoScore, judge, note, patrol, points, wait, useTargetScoring, syncQueue, pushAlert]);
+  }, [autoScore, judge, note, patrol, points, wait, useTargetScoring, syncQueue, pushAlert, resetForm]);
 
-  const totalAnswers = useMemo(() => (patrol ? parseAnswerLetters(categoryAnswers[patrol.category] || '').length : 0), [patrol, categoryAnswers]);
+  const totalAnswers = useMemo(
+    () => (patrol ? parseAnswerLetters(categoryAnswers[patrol.category] || '').length : 0),
+    [patrol, categoryAnswers]
+  );
+
+  const heroBadges = useMemo(
+    () => [
+      `Event: ${eventId.slice(0, 8)}…`,
+      `Stanoviště: ${stationId.slice(0, 8)}…`,
+      pendingCount ? `Offline fronta: ${pendingCount}` : 'Offline fronta prázdná',
+    ],
+    [pendingCount]
+  );
 
   return (
     <div className="app-shell">
-      <header className="topbar">
-        <div>
-          <h1>Seton – Stanoviště</h1>
-          <p>
-            Event: <code>{eventId}</code>
-            {' • '}Stanoviště: <code>{stationId}</code>
-          </p>
+      <header className="hero">
+        <div className="hero-brand">
+          <div className="hero-logo" aria-hidden>
+            <span>🪢</span>
+          </div>
+          <div>
+            <h1>Uzlování – stanoviště</h1>
+            <p>Webová podpora rozhodčích s QR skenerem, automatickým hodnocením a offline frontou.</p>
+          </div>
         </div>
-        <div className="alerts">
-          {alerts.map((msg, idx) => (
-            <div key={idx} className="alert">
-              {msg}
-            </div>
+        <div className="hero-meta">
+          {heroBadges.map((badge) => (
+            <span key={badge} className="meta-pill">
+              {badge}
+            </span>
           ))}
+          {lastSavedAt ? (
+            <span className="meta-pill subtle">Poslední záznam: {formatTime(lastSavedAt)}</span>
+          ) : null}
+          {syncing ? <span className="meta-pill subtle">Synchronizuji frontu…</span> : null}
         </div>
       </header>
 
-      <main className="layout">
-        <section className="card">
-          <h2>Správné odpovědi (12 otázek)</h2>
-          {loadingAnswers ? <p>Načítám…</p> : null}
-          <div className="answers-grid">
-            {ANSWER_CATEGORIES.map((cat) => (
-              <label key={cat} className="answers-field">
-                <span>{cat}</span>
-                <input
-                  value={answersForm[cat]}
-                  onChange={(e) =>
-                    setAnswersForm((prev) => ({ ...prev, [cat]: e.target.value.toUpperCase() }))
-                  }
-                  placeholder="např. A B C D ..."
-                />
-              </label>
+      <main className="content">
+        {alerts.length ? (
+          <div className="alerts">
+            {alerts.map((msg, idx) => (
+              <div key={idx} className="alert">
+                {msg}
+              </div>
             ))}
           </div>
-          <button onClick={saveCategoryAnswers} disabled={savingAnswers}>
-            {savingAnswers ? 'Ukládám…' : 'Uložit správné odpovědi'}
-          </button>
+        ) : null}
+
+        <section className="card answers-card">
+          <header className="card-header">
+            <div>
+              <h2>Správné odpovědi</h2>
+              <p className="card-subtitle">Každá kategorie musí mít 12 odpovědí (A–D).</p>
+            </div>
+            <button type="button" className="ghost" onClick={() => setAnswersEditorOpen((prev) => !prev)}>
+              {answersEditorOpen ? 'Zobrazit přehled' : 'Upravit odpovědi'}
+            </button>
+          </header>
+          {loadingAnswers ? <p>Načítám…</p> : null}
+          {!answersEditorOpen ? (
+            <div className="answers-summary">
+              {ANSWER_CATEGORIES.map((cat) => {
+                const stored = categoryAnswers[cat];
+                const letters = parseAnswerLetters(stored || '');
+                return (
+                  <div key={cat} className="answers-summary-row">
+                    <span className="answers-tag">{cat}</span>
+                    <span className="answers-value">
+                      {letters.length ? `${letters.length} • ${letters.join(' ')}` : 'Nenastaveno'}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="answers-editor">
+              <div className="answers-grid">
+                {ANSWER_CATEGORIES.map((cat) => (
+                  <label key={cat} className="answers-field">
+                    <span>{cat}</span>
+                    <input
+                      value={answersForm[cat]}
+                      onChange={(event) =>
+                        setAnswersForm((prev) => ({ ...prev, [cat]: event.target.value.toUpperCase() }))
+                      }
+                      placeholder="např. A B C D …"
+                    />
+                  </label>
+                ))}
+              </div>
+              <div className="answers-actions">
+                <button type="button" className="primary" onClick={saveCategoryAnswers} disabled={savingAnswers}>
+                  {savingAnswers ? 'Ukládám…' : 'Uložit správné odpovědi'}
+                </button>
+                <button type="button" className="ghost" onClick={loadCategoryAnswers} disabled={loadingAnswers}>
+                  Znovu načíst
+                </button>
+              </div>
+            </div>
+          )}
         </section>
 
-        <section className="card">
-          <h2>Skener hlídek</h2>
+        <section className="card scanner-card">
+          <div className="scanner-icon" aria-hidden>
+            <span>📷</span>
+          </div>
+          <div className="scanner-copy">
+            <h2>Skener hlídek</h2>
+            <p>Naskenuj QR kód nebo zadej kód ručně. Po načtení se formulář otevře automaticky.</p>
+          </div>
           <div className="scanner-wrapper">
             <QRScanner active={scanActive} onResult={handleScanResult} onError={(err) => console.error(err)} />
             <div className="manual-entry">
               <label>
-                Ruční kód:
+                Ruční kód
                 <input
                   value={manualCode}
-                  onChange={(e) => setManualCode(e.target.value)}
+                  onChange={(event) => setManualCode(event.target.value)}
                   placeholder="např. NH-15"
                 />
               </label>
-              <button onClick={() => manualCode.trim() && fetchPatrol(manualCode.trim())}>Načíst hlídku</button>
+              <button
+                type="button"
+                className="primary"
+                onClick={() => manualCode.trim() && fetchPatrol(manualCode.trim())}
+              >
+                Načíst hlídku
+              </button>
             </div>
+            {patrol ? (
+              <div className="scanner-preview">
+                <strong>{patrol.team_name}</strong>
+                <span>
+                  {patrol.category}/{patrol.sex}
+                </span>
+              </div>
+            ) : (
+              <p className="scanner-placeholder">Nejprve naskenuj QR kód hlídky.</p>
+            )}
           </div>
         </section>
 
-        <section className="card">
-          <h2>Formulář stanoviště</h2>
+        <section className="card form-card">
+          <header className="card-header">
+            <div>
+              <h2>Stanovištní formulář</h2>
+              <p className="card-subtitle">Vyplň body, čekací dobu, poznámku a potvrď uložení.</p>
+            </div>
+            <button type="button" className="ghost" onClick={resetForm}>
+              Vymazat
+            </button>
+          </header>
           {patrol ? (
             <div className="form-grid">
               <div className="patrol-meta">
@@ -570,61 +683,63 @@ function App() {
               </div>
               <label>
                 Rozhodčí
-                <input value={judge} onChange={(e) => setJudge(e.target.value)} placeholder="Jméno" />
+                <input value={judge} onChange={(event) => setJudge(event.target.value)} placeholder="Jméno" />
               </label>
               <label>
                 Čekací doba (minuty)
-                <input value={wait} onChange={(e) => setWait(e.target.value)} type="number" min={0} />
+                <input value={wait} onChange={(event) => setWait(event.target.value)} type="number" min={0} />
               </label>
               <label>
                 Poznámka
-                <textarea value={note} onChange={(e) => setNote(e.target.value)} rows={3} />
+                <textarea value={note} onChange={(event) => setNote(event.target.value)} rows={3} />
               </label>
-
               <label className="switch-field">
                 <input
                   type="checkbox"
                   checked={useTargetScoring}
-                  onChange={(e) => setUseTargetScoring(e.target.checked)}
+                  onChange={(event) => setUseTargetScoring(event.target.checked)}
                 />
                 <span>Vyhodnotit terčový úsek</span>
               </label>
-
               {useTargetScoring ? (
                 <div className="auto-section">
                   <label>
-                    Odpovědi hlídky ({totalAnswers || '–'}):
+                    Odpovědi hlídky ({totalAnswers || '–'})
                     <input
                       value={answersInput}
-                      onChange={(e) => setAnswersInput(e.target.value.toUpperCase())}
-                      placeholder="např. A B C D ..."
+                      onChange={(event) => setAnswersInput(event.target.value.toUpperCase())}
+                      placeholder="např. A B C D …"
                     />
                   </label>
-                  <p>
-                    Správně: {autoScore.correct} / {autoScore.total}
-                  </p>
+                  <p className="auto-score">Správně: {autoScore.correct} / {autoScore.total}</p>
                   {answersError ? <p className="error-text">{answersError}</p> : null}
                 </div>
               ) : (
                 <label>
                   Body (-12 až 12)
-                  <input value={points} onChange={(e) => setPoints(e.target.value)} type="number" min={-12} max={12} />
+                  <input
+                    value={points}
+                    onChange={(event) => setPoints(event.target.value)}
+                    type="number"
+                    min={-12}
+                    max={12}
+                  />
                 </label>
               )}
-
-              <button onClick={handleSave}>Uložit</button>
-              <button className="secondary" onClick={resetForm}>
-                Zrušit
+              <button type="button" className="primary" onClick={handleSave}>
+                Uložit záznam
               </button>
             </div>
           ) : (
-            <p>Nejprve naskenuj hlídku.</p>
+            <p className="form-placeholder">Nejprve naskenuj hlídku a otevři formulář.</p>
           )}
           {pendingCount > 0 ? (
             <div className="pending-banner">
-              <p>Čeká na odeslání: {pendingCount}</p>
-              <button onClick={syncQueue} disabled={syncing}>
-                {syncing ? 'Synchronizuji…' : 'Odeslat nyní'}
+              <div>
+                Čeká na odeslání: {pendingCount} {syncing ? '(synchronizuji…)' : ''}
+              </div>
+              <button type="button" onClick={syncQueue} disabled={syncing}>
+                {syncing ? 'Pracuji…' : 'Odeslat nyní'}
               </button>
             </div>
           ) : null}

--- a/web/src/components/LastScoresList.tsx
+++ b/web/src/components/LastScoresList.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
 import { supabase } from '../supabaseClient';
 
 const eventId = import.meta.env.VITE_EVENT_ID as string | undefined;
@@ -31,13 +32,21 @@ function parseAnswerLetters(value?: string | null) {
   return (value?.match(/[A-D]/gi) || []).map((l) => l.toUpperCase());
 }
 
+interface LoadOptions {
+  skipLoader?: boolean;
+}
+
 export function LastScoresList() {
   const [rows, setRows] = useState<ScoreRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
-  const load = useCallback(async () => {
-    setLoading(true);
+  const refreshTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const load = useCallback(async ({ skipLoader = false }: LoadOptions = {}) => {
+    if (!skipLoader) {
+      setLoading(true);
+    }
     const [scoresRes, quizRes] = await Promise.all([
       supabase
         .from('station_scores')
@@ -71,22 +80,70 @@ export function LastScoresList() {
     }));
 
     setRows(merged);
-  }, []);
+  }, [eventId, stationId]);
 
   useEffect(() => {
     load();
   }, [load]);
 
+  const scheduleRealtimeRefresh = useCallback(() => {
+    if (refreshTimeout.current) {
+      clearTimeout(refreshTimeout.current);
+    }
+    refreshTimeout.current = setTimeout(() => {
+      load({ skipLoader: true });
+    }, 250);
+  }, [load]);
+
+  useEffect(() => {
+    const handleScopedRefresh = (
+      payload: RealtimePostgresChangesPayload<{ event_id?: string; station_id?: string }>
+    ) => {
+      const record = payload.new ?? payload.old;
+      if (record?.event_id !== eventId || record?.station_id !== stationId) {
+        return;
+      }
+      scheduleRealtimeRefresh();
+    };
+
+    const channel = supabase
+      .channel(`station-scores-${eventId}-${stationId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'station_scores' },
+        handleScopedRefresh
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'station_quiz_responses' },
+        handleScopedRefresh
+      )
+      .subscribe();
+
+    return () => {
+      if (refreshTimeout.current) {
+        clearTimeout(refreshTimeout.current);
+        refreshTimeout.current = null;
+      }
+      supabase.removeChannel(channel);
+    };
+  }, [scheduleRealtimeRefresh, eventId, stationId]);
+
   const handleRefresh = async () => {
     setRefreshing(true);
-    await load();
+    await load({ skipLoader: true });
     setRefreshing(false);
   };
+
+  const countLabel = loading ? '…' : rows.length;
 
   return (
     <section className="card">
       <header className="card-header">
-        <h2>Poslední záznamy</h2>
+        <h2>
+          Poslední záznamy{' '}
+          <span className="card-hint">({countLabel})</span>
+        </h2>
         <button onClick={handleRefresh} disabled={loading || refreshing}>
           {refreshing ? 'Obnovuji…' : 'Obnovit'}
         </button>


### PR DESCRIPTION
## Summary
- reintroduce the Supabase-driven station flow with queue syncing, QR scanning, and patrol validation
- add toggleable answer editor, auto scoring controls, and offline status badges within the refreshed hero layout
- restyle cards, alerts, scanner, and results list to match the modern web dashboard while supporting new interactions

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d23b56b3cc83269be62d78cdd3f053