### PR TITLE
Fix GitHub workflow deploy command

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -41,8 +41,5 @@ jobs:
       - name: Pull Vercel environment information
         run: npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Build Vercel artifacts
-        run: npx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-
       - name: Deploy to Vercel
-        run: npx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- remove the local `vercel build` step that failed with `spawn sh ENOENT`
- invoke `vercel deploy --prod --yes` so Vercel performs the remote build during deployment

## Testing
- Not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d261548f90832683c79d9bbe0cfdc7