### PR TITLE
Enhance station workflow with target automation and wait timer

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -371,18 +371,6 @@ textarea {
   gap: 4px;
 }
 
-.switch-field {
-  flex-direction: row;
-  align-items: center;
-  gap: 10px;
-  font-weight: 600;
-}
-
-.switch-field input {
-  width: auto;
-  accent-color: #0d7c54;
-}
-
 .auto-section {
   display: flex;
   flex-direction: column;
@@ -391,6 +379,35 @@ textarea {
 
 .auto-score {
   font-weight: 600;
+}
+
+.wait-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wait-label {
+  font-weight: 600;
+  font-size: 14px;
+  color: #1f2937;
+}
+
+.wait-display {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.wait-display strong {
+  font-size: 20px;
+}
+
+.wait-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .error-text {

--- a/web/src/__tests__/stationFlow.test.tsx
+++ b/web/src/__tests__/stationFlow.test.tsx
@@ -58,6 +58,20 @@ vi.mock('../supabaseClient', () => {
                 }),
               }),
             };
+          case 'stations':
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    maybeSingle: () =>
+                      Promise.resolve({
+                        data: { code: 'X', name: 'Testovací stanoviště' },
+                        error: null,
+                      }),
+                  }),
+                }),
+              }),
+            };
           case 'station_passages':
             return {
               upsert: () => Promise.resolve({ error: new Error('Offline') }),
@@ -122,7 +136,7 @@ describe('station workflow', () => {
     await screen.findAllByText(/Vlci/);
 
     await user.type(screen.getByPlaceholderText('Jméno'), 'Honza');
-    const pointsInput = screen.getByLabelText('Body (-12 až 12)');
+    const pointsInput = screen.getByLabelText('Body (0 až 12)');
     await user.clear(pointsInput);
     await user.type(pointsInput, '10');
 

--- a/web/src/env.d.ts
+++ b/web/src/env.d.ts
@@ -5,6 +5,7 @@ declare interface ImportMetaEnv {
   readonly VITE_SUPABASE_ANON_KEY: string;
   readonly VITE_EVENT_ID: string;
   readonly VITE_STATION_ID: string;
+  readonly VITE_ADMIN_MODE?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- fetch station metadata to detect target stations/admin mode and guard answer management
- add wait-timer based queue tracking and restrict manual scoring to 0-12 points with refreshed form UI
- show target-only sections and quiz data conditionally, updating list/test fixtures accordingly

## Testing
- npm run lint
- npm run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d27678b0208326bfb2f89a9835bb53