### PR TITLE
Fix Vercel CLI cwd in deploy workflow

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Pull Vercel environment information
         run: npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: web
 
       - name: Deploy to Vercel
         run: npx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: web


### PR DESCRIPTION
## Summary
- run Vercel CLI steps from the repository root so Vercel uses the configured root directory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d29f9558e083268cfff50e453908b0