### PR TITLE
Harden Supabase record typing and QR scanner handling

### DIFF
--- a/web/src/components/TargetAnswersReport.tsx
+++ b/web/src/components/TargetAnswersReport.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { supabase } from '../supabaseClient';
+import { unwrapRelation } from './utils';
 
 const eventId = import.meta.env.VITE_EVENT_ID as string | undefined;
 const stationId = import.meta.env.VITE_STATION_ID as string | undefined;
@@ -30,6 +31,17 @@ function formatDate(value: string) {
   return new Date(value).toLocaleString('cs-CZ');
 }
 
+type TargetRowRecord = Omit<TargetRow, 'patrols'> & {
+  patrols?: TargetRow['patrols'] | TargetRow['patrols'][] | null;
+};
+
+function mapTargetRows(rows: TargetRowRecord[] = []): TargetRow[] {
+  return rows.map((row) => ({
+    ...row,
+    patrols: unwrapRelation(row.patrols) ?? null,
+  }));
+}
+
 export default function TargetAnswersReport() {
   const [rows, setRows] = useState<TargetRow[]>([]);
   const [loading, setLoading] = useState(false);
@@ -54,7 +66,7 @@ export default function TargetAnswersReport() {
       return;
     }
 
-    setRows(data || []);
+    setRows(mapTargetRows((data ?? []) as TargetRowRecord[]));
   }, [eventId, stationId]);
 
   useEffect(() => {

--- a/web/src/components/utils.ts
+++ b/web/src/components/utils.ts
@@ -1,0 +1,12 @@
+export function unwrapRelation<T>(value: T | T[] | null | undefined): T | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+
+  return value;
+}
+

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "moduleResolution": "Bundler",
     "allowImportingTsExtensions": false,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,12 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    target: 'es2022',
+  },
+  esbuild: {
+    target: 'es2022',
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- normalize Supabase relation payloads via a shared helper and tighten typing in recent score and target report components
- update the QR scanner to use @zxing/browser controls, improve permission error reporting, and clean up camera resources
- align TypeScript and Vite targets with ES2022 so modern helpers such as Array.prototype.at type-check correctly

## Testing
- npm run lint
- npx tsc --noEmit
- npm test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2af7beefc8326ab01448468593fdc