### PR TITLE
Allow selecting station in scoring app

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -73,6 +73,51 @@ body {
   gap: 12px;
 }
 
+.station-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 220px;
+  padding: 8px 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 16px 28px rgba(15, 118, 110, 0.2);
+}
+
+.station-selector label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.76);
+}
+
+.station-selector select {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.36);
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.9);
+  color: #0a4236;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.station-selector select:focus {
+  outline: 3px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 2px;
+}
+
+.station-selector select:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.station-selector-error {
+  font-size: 12px;
+  color: #ffe0e0;
+}
+
 .meta-pill {
   display: inline-flex;
   align-items: center;

--- a/web/src/__tests__/stationFlow.test.tsx
+++ b/web/src/__tests__/stationFlow.test.tsx
@@ -59,17 +59,25 @@ vi.mock('../supabaseClient', () => {
         };
       case 'stations':
         return {
-          select: () => ({
-            eq: () => ({
+          select: () => {
+            const listResult = Promise.resolve({
+              data: [{ id: 'station-test', code: 'X', name: 'Testovací stanoviště' }],
+              error: null,
+            });
+            const maybeSingleResult = Promise.resolve({
+              data: { code: 'X', name: 'Testovací stanoviště' },
+              error: null,
+            });
+            return {
               eq: () => ({
-                maybeSingle: () =>
-                  Promise.resolve({
-                    data: { code: 'X', name: 'Testovací stanoviště' },
-                    error: null,
-                  }),
+                eq: () => ({
+                  maybeSingle: () => maybeSingleResult,
+                }),
+                order: () => listResult,
               }),
-            }),
-          }),
+              order: () => listResult,
+            };
+          },
         };
       case 'station_passages':
         return {
@@ -149,16 +157,24 @@ interface SupabaseTestClient {
 
 const supabaseMock = supabase as unknown as SupabaseTestClient;
 
-const QUEUE_KEY = 'web_pending_station_submissions_v1';
+const QUEUE_KEY = 'web_pending_station_submissions_v1_station-test';
 
 function createMaybeSingleResult<T>(data: T, error: unknown = null) {
+  const row = {
+    id: 'station-test',
+    code: (data as unknown as { code?: string }).code ?? 'X',
+    name: (data as unknown as { name?: string | null }).name ?? null,
+  };
+  const listResult = Promise.resolve({ data: [row], error: null });
   return {
     select: () => ({
       eq: () => ({
         eq: () => ({
           maybeSingle: () => Promise.resolve({ data, error }),
         }),
+        order: () => listResult,
       }),
+      order: () => listResult,
     }),
   };
 }

--- a/web/src/components/LastScoresList.tsx
+++ b/web/src/components/LastScoresList.tsx
@@ -3,13 +3,6 @@ import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
 import { supabase } from '../supabaseClient';
 import { unwrapRelation } from './utils';
 
-const eventId = import.meta.env.VITE_EVENT_ID as string | undefined;
-const stationId = import.meta.env.VITE_STATION_ID as string | undefined;
-
-if (!eventId || !stationId) {
-  throw new Error('Missing VITE_EVENT_ID or VITE_STATION_ID environment variable.');
-}
-
 interface ScoreRow {
   id: string;
   created_at: string;
@@ -53,10 +46,12 @@ interface LoadOptions {
 }
 
 interface LastScoresListProps {
+  eventId: string;
+  stationId: string;
   isTargetStation: boolean;
 }
 
-export function LastScoresList({ isTargetStation }: LastScoresListProps) {
+export function LastScoresList({ eventId, stationId, isTargetStation }: LastScoresListProps) {
   const [rows, setRows] = useState<ScoreRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);

--- a/web/src/components/TargetAnswersReport.tsx
+++ b/web/src/components/TargetAnswersReport.tsx
@@ -2,13 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { supabase } from '../supabaseClient';
 import { unwrapRelation } from './utils';
 
-const eventId = import.meta.env.VITE_EVENT_ID as string | undefined;
-const stationId = import.meta.env.VITE_STATION_ID as string | undefined;
-
-if (!eventId || !stationId) {
-  throw new Error('Missing VITE_EVENT_ID or VITE_STATION_ID environment variable.');
-}
-
 interface TargetRow {
   patrol_id: string;
   correct_count: number;
@@ -42,7 +35,12 @@ function mapTargetRows(rows: TargetRowRecord[] = []): TargetRow[] {
   }));
 }
 
-export default function TargetAnswersReport() {
+interface TargetAnswersReportProps {
+  eventId: string;
+  stationId: string;
+}
+
+export default function TargetAnswersReport({ eventId, stationId }: TargetAnswersReportProps) {
   const [rows, setRows] = useState<TargetRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/web/src/env.d.ts
+++ b/web/src/env.d.ts
@@ -4,7 +4,7 @@ declare interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL: string;
   readonly VITE_SUPABASE_ANON_KEY: string;
   readonly VITE_EVENT_ID: string;
-  readonly VITE_STATION_ID: string;
+  readonly VITE_STATION_ID?: string;
   readonly VITE_ADMIN_MODE?: string;
 }
 


### PR DESCRIPTION
## Summary
- add a station selector that loads available stations, persists the choice, and updates related UI badges
- adjust queue handling and station-specific queries to respect the selected station and pass IDs via props
- update tests and mocks for per-station queues and station list loading

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d2b72f049c832699c1a6d1ea087626