### PR TITLE
Add argon2 type declarations for edge function

### DIFF
--- a/supabase/functions/types.d.ts
+++ b/supabase/functions/types.d.ts
@@ -7,6 +7,31 @@ declare module 'https://deno.land/std@0.224.0/csv/mod.ts' {
   export function parse<T>(input: string, options: T): unknown;
 }
 
+declare module 'https://deno.land/x/argon2@v0.3.2/mod.ts' {
+  export enum ArgonType {
+    Argon2d = 0,
+    Argon2i = 1,
+    Argon2id = 2,
+  }
+
+  export type ArgonHashOptions = {
+    timeCost?: number;
+    memoryCost?: number;
+    parallelism?: number;
+    hashLength?: number;
+    salt?: string | Uint8Array;
+    associatedData?: string | Uint8Array;
+    type?: ArgonType;
+    version?: number;
+    raw?: boolean;
+  };
+
+  export function hash(
+    password: string | Uint8Array,
+    options?: ArgonHashOptions,
+  ): Promise<string>;
+}
+
 type DenoServeHandler = (req: Request) => Response | Promise<Response>;
 type DenoServeOptions = {
   port?: number;


### PR DESCRIPTION
## Summary
- add ambient module declarations for the Deno argon2 import used by the sync-judges function to satisfy TypeScript

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db8c0bab5883268ae6f0f344f52038