### PR TITLE
Update tab branding to Seton

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Seton</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,12 +3,40 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import { AuthProvider } from './auth/context';
 import { registerSW } from 'virtual:pwa-register';
+import setonLogo from './assets/seton-logo.png';
+
+function applyBranding() {
+  if (document.title !== 'Seton') {
+    document.title = 'Seton';
+  }
+
+  const existingLinks = Array.from(
+    document.querySelectorAll<HTMLLinkElement>("link[rel~='icon']"),
+  );
+
+  if (existingLinks.length > 0) {
+    existingLinks.forEach((link) => {
+      link.rel = 'icon';
+      link.type = 'image/png';
+      link.href = setonLogo;
+    });
+    return;
+  }
+
+  const link = document.createElement('link');
+  link.rel = 'icon';
+  link.type = 'image/png';
+  link.href = setonLogo;
+  document.head.appendChild(link);
+}
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
 if ('serviceWorker' in navigator) {
   registerSW({ immediate: true });
 }
+
+applyBranding();
 
 const params = new URLSearchParams(window.location.search);
 const view = params.get('view');

--- a/web/src/scoreboard/ScoreboardApp.tsx
+++ b/web/src/scoreboard/ScoreboardApp.tsx
@@ -283,7 +283,7 @@ function ScoreboardApp() {
   }, [loadData]);
 
   useEffect(() => {
-    document.title = 'Seton – Výsledky';
+    document.title = 'Seton';
   }, []);
 
   const groupedRanked = useMemo(() => {


### PR DESCRIPTION
## Summary
- set the document title to "Seton" by default and ensure the favicon uses the Seton logo
- update the scoreboard view to keep the same tab title across the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db8cd0666483268bec2984bccd4354