### PR TITLE
Fix auth initialization flicker

### DIFF
--- a/web/src/auth/context.tsx
+++ b/web/src/auth/context.tsx
@@ -179,22 +179,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     encryptedDeviceKey: { ciphertext: string; iv: string; deviceSalt: string };
   } | null>(null);
 
-  useInitialization(async (state) => {
-    if (state.state === 'locked' || state.state === 'unauthenticated') {
-      const data = await bootstrap();
-      if (data) {
-        setCachedData({
-          manifest: data.manifest,
-          patrols: data.patrols,
-          tokens: data.tokens,
-          encryptedDeviceKey: data.encryptedDeviceKey,
-        });
+  const handleInitializationState = useCallback(
+    async (state: AuthStatus) => {
+      if (state.state === 'locked' || state.state === 'unauthenticated') {
+        const data = await bootstrap();
+        if (data) {
+          setCachedData({
+            manifest: data.manifest,
+            patrols: data.patrols,
+            tokens: data.tokens,
+            encryptedDeviceKey: data.encryptedDeviceKey,
+          });
+        }
+      } else if (state.state === 'error') {
+        setCachedData(null);
       }
-    } else if (state.state === 'error') {
-      setCachedData(null);
-    }
-    setStatus(state);
-  });
+      setStatus(state);
+    },
+    [setCachedData, setStatus],
+  );
+
+  useInitialization(handleInitializationState);
 
   const login = useCallback(
     async ({ email, password, pin }: { email: string; password: string; pin?: string }) => {


### PR DESCRIPTION
## Summary
- memoize the AuthProvider initialization callback so the effect only runs once on mount
- preserve cached authentication data updates when initialization resolves

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68db92e2b1688326a3c17e17c95bc869