### PR TITLE
Fix Supabase auth rewrite path

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/auth/(.*)",
-      "destination": "https://vdkbdnxkpeeqxnruwiah.supabase.co/functions/v1/$1"
+      "destination": "https://vdkbdnxkpeeqxnruwiah.supabase.co/functions/v1/auth/$1"
     },
     {
       "source": "/stations/(.*)",


### PR DESCRIPTION
## Summary
- fix the Vercel rewrite for `/auth/*` so requests reach the Supabase `auth` function rather than a missing `login` function

## Testing
- no automated tests were run (config change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbe43e9eac8326a158edd470c075a1