### PR TITLE
Implement password change flow for judges

### DIFF
--- a/web/api/auth/change-password.ts
+++ b/web/api/auth/change-password.ts
@@ -1,0 +1,99 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const PBKDF2_ITERATIONS = 210_000;
+
+function toBase64(buffer: ArrayBuffer) {
+  return Buffer.from(buffer).toString('base64');
+}
+
+async function hashPassword(password: string): Promise<string> {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey('raw', encoder.encode(password), { name: 'PBKDF2' }, false, [
+    'deriveBits',
+  ]);
+  const derivedBits = await crypto.subtle.deriveBits(
+    { name: 'PBKDF2', hash: 'SHA-256', salt, iterations: PBKDF2_ITERATIONS },
+    key,
+    256,
+  );
+  return `pbkdf2$sha256$${PBKDF2_ITERATIONS}$${toBase64(salt.buffer)}$${toBase64(derivedBits)}`;
+}
+
+export default async function handler(req: any, res: any) {
+  const cors = {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'POST, OPTIONS',
+    'access-control-allow-headers': 'content-type',
+  };
+
+  res.setHeader('Access-Control-Allow-Origin', cors['access-control-allow-origin']);
+  res.setHeader('Access-Control-Allow-Methods', cors['access-control-allow-methods']);
+  res.setHeader('Access-Control-Allow-Headers', cors['access-control-allow-headers']);
+
+  if (req.method === 'OPTIONS') {
+    return res
+      .status(200)
+      .setHeader('Access-Control-Allow-Origin', cors['access-control-allow-origin'])
+      .setHeader('Access-Control-Allow-Methods', cors['access-control-allow-methods'])
+      .setHeader('Access-Control-Allow-Headers', cors['access-control-allow-headers'])
+      .end();
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const { email, userId, id, newPassword } = req.body ?? {};
+  const resolvedEmail = typeof email === 'string' ? email : undefined;
+  const resolvedId = typeof userId === 'string' ? userId : typeof id === 'string' ? id : undefined;
+
+  if (typeof newPassword !== 'string' || newPassword.length === 0) {
+    return res.status(400).json({ error: 'Missing new password' });
+  }
+
+  if (!resolvedEmail && !resolvedId) {
+    return res.status(400).json({ error: 'Missing user identifier' });
+  }
+
+  const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+  let query = supabase.from('judges').select('id, email').limit(1);
+
+  if (resolvedId) {
+    query = query.eq('id', resolvedId);
+  } else if (resolvedEmail) {
+    query = query.eq('email', resolvedEmail);
+  }
+
+  const { data: judge, error: fetchError } = await query.maybeSingle();
+
+  if (fetchError) {
+    console.error('Failed to load judge for password change', fetchError);
+    return res.status(500).json({ error: 'DB error' });
+  }
+
+  if (!judge) {
+    return res.status(404).json({ error: 'Judge not found' });
+  }
+
+  const password_hash = await hashPassword(newPassword);
+  const nowIso = new Date().toISOString();
+
+  const { error: updateError } = await supabase
+    .from('judges')
+    .update({ password_hash, must_change_password: false, password_rotated_at: nowIso })
+    .eq('id', judge.id);
+
+  if (updateError) {
+    console.error('Failed to update password', updateError);
+    return res.status(500).json({ error: 'Failed to change password' });
+  }
+
+  return res
+    .status(200)
+    .setHeader('Access-Control-Allow-Origin', cors['access-control-allow-origin'])
+    .json({ success: true });
+}

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1062,6 +1062,33 @@ textarea {
   transform: translateY(1px);
 }
 
+.auth-secondary {
+  appearance: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: transparent;
+  color: #e2e8f0;
+  font-weight: 500;
+  font-size: 1rem;
+  cursor: pointer;
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.auth-secondary:not(:disabled):hover {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: rgba(148, 163, 184, 0.65);
+}
+
+.auth-secondary:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
 .tickets-card {
   display: flex;
   flex-direction: column;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import './App.css';
 import zelenaLigaLogo from './assets/znak_SPTO_transparent.png';
 import { useAuth } from './auth/context';
 import LoginScreen from './auth/LoginScreen';
+import ChangePasswordScreen from './auth/ChangePasswordScreen';
 import type { AuthStatus } from './auth/types';
 import { signPayload } from './auth/crypto';
 import TicketQueue from './components/TicketQueue';
@@ -1651,6 +1652,16 @@ function App() {
 
   if (status.state === 'unauthenticated') {
     return <LoginScreen />;
+  }
+
+  if (status.state === 'password-change-required') {
+    return (
+      <ChangePasswordScreen
+        email={status.email}
+        judgeId={status.judgeId}
+        pendingPin={status.pendingPin}
+      />
+    );
   }
 
   if (status.state === 'locked') {

--- a/web/src/auth/ChangePasswordScreen.tsx
+++ b/web/src/auth/ChangePasswordScreen.tsx
@@ -1,0 +1,104 @@
+import { FormEvent, useEffect, useRef, useState } from 'react';
+import { changePasswordRequest } from './api';
+import { useAuth } from './context';
+
+interface Props {
+  email: string;
+  judgeId?: string;
+  pendingPin?: string;
+}
+
+export default function ChangePasswordScreen({ email, judgeId, pendingPin }: Props) {
+  const { login, logout } = useAuth();
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newPassword || !confirmPassword) {
+      setError('Vyplň prosím nové heslo.');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError('Hesla se neshodují.');
+      return;
+    }
+
+    setError('');
+    setLoading(true);
+
+    try {
+      await changePasswordRequest({
+        email,
+        id: judgeId,
+        newPassword,
+      });
+      await login({ email, password: newPassword, pin: pendingPin });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return;
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div className="auth-shell">
+      <form className="auth-card" onSubmit={handleSubmit}>
+        <h1>Změna hesla</h1>
+        <p className="auth-description">
+          Účet <strong>{email}</strong> vyžaduje nastavení nového hesla.
+        </p>
+
+        <label className="auth-field">
+          <span>Nové heslo</span>
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={newPassword}
+            onChange={(event) => setNewPassword(event.target.value)}
+            required
+          />
+        </label>
+
+        <label className="auth-field">
+          <span>Potvrzení hesla</span>
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            required
+          />
+        </label>
+
+        {error ? <p className="auth-error">{error}</p> : null}
+
+        <button type="submit" className="auth-primary" disabled={loading}>
+          {loading ? 'Ukládám…' : 'Nastavit heslo'}
+        </button>
+        <button
+          type="button"
+          className="auth-secondary"
+          onClick={() => {
+            void logout();
+          }}
+          disabled={loading}
+        >
+          Zpět na přihlášení
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/auth/api.ts
+++ b/web/src/auth/api.ts
@@ -26,6 +26,15 @@ export function loginRequest(email: string, password: string, devicePublicKey?: 
   }).then((res) => handleResponse<LoginResponse>(res));
 }
 
+export function changePasswordRequest(params: { email?: string; id?: string; newPassword: string }) {
+  const url = `${BASE_URL}/auth/change-password`;
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  }).then((res) => handleResponse<{ success: true }>(res));
+}
+
 export function fetchManifest(accessToken: string) {
   const url = `${BASE_URL}/manifest`;
   return fetch(url, {

--- a/web/src/auth/types.ts
+++ b/web/src/auth/types.ts
@@ -1,4 +1,4 @@
-export interface LoginResponse {
+export interface LoginSuccessResponse {
   access_token: string;
   access_token_expires_in: number;
   refresh_token: string;
@@ -7,6 +7,14 @@ export interface LoginResponse {
   manifest: StationManifest;
   patrols: PatrolSummary[];
 }
+
+export interface LoginRequiresPasswordChangeResponse {
+  id?: string;
+  must_change_password: true;
+  email?: string | null;
+}
+
+export type LoginResponse = LoginSuccessResponse | LoginRequiresPasswordChangeResponse;
 
 export interface StationManifest {
   judge: {
@@ -54,6 +62,7 @@ export type AuthStatus =
   | { state: 'locked'; requiresPin: boolean }
   | { state: 'unauthenticated' }
   | { state: 'error'; message: string }
+  | { state: 'password-change-required'; email: string; judgeId?: string; pendingPin?: string }
   | {
       state: 'authenticated';
       manifest: StationManifest;

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -5,6 +5,10 @@
       "destination": "/api/auth/login"
     },
     {
+      "source": "/auth/change-password",
+      "destination": "/api/auth/change-password"
+    },
+    {
       "source": "/auth/(.*)",
       "destination": "https://vdkbdnxkpeeqxnruwiah.supabase.co/functions/v1/$1"
     },


### PR DESCRIPTION
## Summary
- add a serverless change-password endpoint that hashes with PBKDF2 and updates the judge record
- show a dedicated change-password screen when login requires it and retry authentication afterwards
- expose the new client helpers, status handling, styles, and rewrite so the flow works end-to-end

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbf0d8c830832696ed5a37ba96dc2f