### PR TITLE
Fix judge login email lookup to be case-insensitive

### DIFF
--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -72,12 +72,13 @@ authRouter.post('/login', async (req, res) => {
   }
 
   const { email, password, devicePublicKey } = parse.data;
-  const lowerEmail = email.toLowerCase();
+  const normalizedEmail = email.trim();
 
   const { data: judge, error: judgeError } = await supabase
     .from('judges')
     .select('*')
-    .eq('email', lowerEmail)
+    .ilike('email', normalizedEmail)
+    .limit(1)
     .maybeSingle();
 
   if (judgeError || !judge) {


### PR DESCRIPTION
## Summary
- trim the supplied judge email before authentication lookup
- perform the Supabase judge query case-insensitively and limit to a single record

## Testing
- npm run build (server)


------
https://chatgpt.com/codex/tasks/task_e_68dbfb0cb08c8326ab9aa4490ec49df9