### PR TITLE
Add station page routing after login

### DIFF
--- a/web/src/__tests__/stationRouting.test.tsx
+++ b/web/src/__tests__/stationRouting.test.tsx
@@ -1,0 +1,82 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { AuthStatus } from '../auth/types';
+
+let useStationRouting: (status: AuthStatus) => void;
+
+beforeAll(async () => {
+  vi.stubEnv('VITE_SUPABASE_URL', 'http://localhost');
+  vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+  ({ useStationRouting } = await import('../App'));
+});
+
+describe('useStationRouting', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('redirects to station path after authentication', () => {
+    const initialStatus: AuthStatus = { state: 'loading' };
+    const stationStatus: AuthStatus = {
+      state: 'authenticated',
+      manifest: {
+        judge: { id: 'judge-1', email: 'judge@example.com', displayName: 'Test Judge' },
+        station: { id: 'station-123', code: 'X', name: 'Stanoviště X' },
+        event: { id: 'event-1', name: 'Test Event' },
+        allowedCategories: [],
+        allowedTasks: [],
+        manifestVersion: 1,
+      },
+      patrols: [],
+      deviceKey: new Uint8Array(0),
+      tokens: {
+        accessToken: 'access',
+        accessTokenExpiresAt: Date.now() + 1,
+        refreshToken: 'refresh',
+        sessionId: 'session',
+      },
+    };
+
+    const { rerender } = renderHook(({ status }) => useStationRouting(status), {
+      initialProps: { status: initialStatus },
+    });
+
+    rerender({ status: stationStatus });
+
+    expect(window.location.pathname).toBe('/stations/station-123');
+  });
+
+  it('clears station path when returning to login', () => {
+    const stationStatus: AuthStatus = {
+      state: 'authenticated',
+      manifest: {
+        judge: { id: 'judge-1', email: 'judge@example.com', displayName: 'Test Judge' },
+        station: { id: 'station-123', code: 'X', name: 'Stanoviště X' },
+        event: { id: 'event-1', name: 'Test Event' },
+        allowedCategories: [],
+        allowedTasks: [],
+        manifestVersion: 1,
+      },
+      patrols: [],
+      deviceKey: new Uint8Array(0),
+      tokens: {
+        accessToken: 'access',
+        accessTokenExpiresAt: Date.now() + 1,
+        refreshToken: 'refresh',
+        sessionId: 'session',
+      },
+    };
+
+    const unauthStatus: AuthStatus = { state: 'unauthenticated' };
+
+    const { rerender } = renderHook(({ status }) => useStationRouting(status), {
+      initialProps: { status: stationStatus },
+    });
+
+    expect(window.location.pathname).toBe('/stations/station-123');
+
+    rerender({ status: unauthStatus });
+
+    expect(window.location.pathname).toBe('/');
+  });
+});


### PR DESCRIPTION
## Summary
- update the app to push the logged-in judge to their assigned station URL and clear it when access is lost
- add unit coverage for the station routing behaviour

## Testing
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68dbfd0c90a08326a430149edc86a434