### PR TITLE
Add station page routing after login

### DIFF
--- a/supabase/sql/schema.sql
+++ b/supabase/sql/schema.sql
@@ -45,6 +45,16 @@ do $$ begin
   end if;
 exception when duplicate_object then null; end $$;
 
+do $$ begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'stations_id_event_key'
+  ) then
+    alter table stations add constraint stations_id_event_key unique (id, event_id);
+  end if;
+exception when duplicate_object then null; end $$;
+
 create table if not exists station_passages (
   id uuid primary key default gen_random_uuid(),
   event_id uuid not null references events(id) on delete cascade,
@@ -153,6 +163,20 @@ create table if not exists judge_assignments (
   created_at timestamptz not null default now(),
   unique (judge_id, station_id, event_id)
 );
+
+do $$ begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'judge_assignments_station_event_fkey'
+  ) then
+    alter table judge_assignments
+      add constraint judge_assignments_station_event_fkey
+      foreign key (station_id, event_id)
+      references stations(id, event_id)
+      on delete cascade;
+  end if;
+exception when duplicate_object then null; end $$;
 
 create table if not exists judge_sessions (
   id uuid primary key default gen_random_uuid(),

--- a/web/src/__tests__/stationRouting.test.tsx
+++ b/web/src/__tests__/stationRouting.test.tsx
@@ -1,0 +1,82 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { AuthStatus } from '../auth/types';
+
+let useStationRouting: (status: AuthStatus) => void;
+
+beforeAll(async () => {
+  vi.stubEnv('VITE_SUPABASE_URL', 'http://localhost');
+  vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+  ({ useStationRouting } = await import('../App'));
+});
+
+describe('useStationRouting', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('redirects to station path after authentication', () => {
+    const initialStatus: AuthStatus = { state: 'loading' };
+    const stationStatus: AuthStatus = {
+      state: 'authenticated',
+      manifest: {
+        judge: { id: 'judge-1', email: 'judge@example.com', displayName: 'Test Judge' },
+        station: { id: 'station-123', code: 'X', name: 'Stanoviště X' },
+        event: { id: 'event-1', name: 'Test Event' },
+        allowedCategories: [],
+        allowedTasks: [],
+        manifestVersion: 1,
+      },
+      patrols: [],
+      deviceKey: new Uint8Array(0),
+      tokens: {
+        accessToken: 'access',
+        accessTokenExpiresAt: Date.now() + 1,
+        refreshToken: 'refresh',
+        sessionId: 'session',
+      },
+    };
+
+    const { rerender } = renderHook(({ status }) => useStationRouting(status), {
+      initialProps: { status: initialStatus },
+    });
+
+    rerender({ status: stationStatus });
+
+    expect(window.location.pathname).toBe('/stations/station-123');
+  });
+
+  it('clears station path when returning to login', () => {
+    const stationStatus: AuthStatus = {
+      state: 'authenticated',
+      manifest: {
+        judge: { id: 'judge-1', email: 'judge@example.com', displayName: 'Test Judge' },
+        station: { id: 'station-123', code: 'X', name: 'Stanoviště X' },
+        event: { id: 'event-1', name: 'Test Event' },
+        allowedCategories: [],
+        allowedTasks: [],
+        manifestVersion: 1,
+      },
+      patrols: [],
+      deviceKey: new Uint8Array(0),
+      tokens: {
+        accessToken: 'access',
+        accessTokenExpiresAt: Date.now() + 1,
+        refreshToken: 'refresh',
+        sessionId: 'session',
+      },
+    };
+
+    const unauthStatus: AuthStatus = { state: 'unauthenticated' };
+
+    const { rerender } = renderHook(({ status }) => useStationRouting(status), {
+      initialProps: { status: stationStatus },
+    });
+
+    expect(window.location.pathname).toBe('/stations/station-123');
+
+    rerender({ status: unauthStatus });
+
+    expect(window.location.pathname).toBe('/');
+  });
+});


### PR DESCRIPTION
## Summary
- update the app to push the logged-in judge to their assigned station URL and clear it when access is lost
- add unit coverage for the station routing behaviour
- improve the judge sync script so it recognises accented station headers and more category separators
- enforce that judge assignments reference stations from the same event via new constraints

## Testing
- npx vitest run --reporter=basic *(fails in this environment: missing browser storage and window)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfd0c90a08326a430149edc86a434