### PR TITLE
Implement proper login response handling

### DIFF
--- a/web/api/auth/login.ts
+++ b/web/api/auth/login.ts
@@ -1,70 +1,280 @@
 // web/api/auth/login.ts
 import { createClient } from '@supabase/supabase-js';
+import argon2 from 'argon2';
+import jwt from 'jsonwebtoken';
+import { pbkdf2 as pbkdf2Callback, randomBytes, timingSafeEqual, createHash } from 'node:crypto';
+import { promisify } from 'node:util';
+
+const pbkdf2 = promisify(pbkdf2Callback);
+
+const REQUIRED_ENV_VARS = [
+  'SUPABASE_URL',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'JWT_SECRET',
+  'REFRESH_TOKEN_SECRET',
+];
+
+for (const name of REQUIRED_ENV_VARS) {
+  if (!process.env[name]) {
+    throw new Error(`Missing environment variable ${name} for auth handler`);
+  }
+}
 
 const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const JWT_SECRET = process.env.JWT_SECRET!;
+const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET!;
+const ACCESS_TOKEN_TTL_SECONDS = Number(process.env.ACCESS_TOKEN_TTL_SECONDS ?? 900);
+const REFRESH_TOKEN_TTL_SECONDS = Number(process.env.REFRESH_TOKEN_TTL_SECONDS ?? 60 * 60 * 24 * 14);
 
-function b64(s: string) { return new Uint8Array(Buffer.from(s, 'base64')); }
-async function verifyPbkdf2(password: string, stored: string) {
-  const [scheme, algo, iterStr, b64Salt, b64Hash] = stored.split('$');
-  if (scheme !== 'pbkdf2' || algo !== 'sha256') return false;
+const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+const corsHeaders = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'POST, OPTIONS',
+  'access-control-allow-headers': 'content-type',
+};
+
+function applyCors(res: any) {
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    res.setHeader(key, value);
+  }
+}
+
+function toIso(date: Date) {
+  return date.toISOString();
+}
+
+function randomToken(bytes = 32) {
+  return randomBytes(bytes).toString('hex');
+}
+
+function createAccessToken(payload: { sub: string; stationId: string; sessionId: string; eventId: string }) {
+  return jwt.sign({ ...payload, type: 'access' }, JWT_SECRET, { expiresIn: ACCESS_TOKEN_TTL_SECONDS });
+}
+
+function createRefreshToken(payload: { sub: string; stationId: string; sessionId: string; eventId: string }) {
+  return jwt.sign({ ...payload, type: 'refresh' }, REFRESH_TOKEN_SECRET, { expiresIn: REFRESH_TOKEN_TTL_SECONDS });
+}
+
+function hashRefreshToken(token: string) {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function isPbkdf2Hash(hash: string) {
+  return hash.startsWith('pbkdf2$');
+}
+
+async function verifyPbkdf2(hash: string, password: string) {
+  const parts = hash.split('$');
+  if (parts.length !== 5) {
+    return false;
+  }
+
+  const [, algo, iterStr, b64Salt, b64Hash] = parts;
+  if (algo !== 'sha256') {
+    return false;
+  }
+
   const iterations = Number(iterStr);
-  const salt = b64(b64Salt);
-  const expected = b64(b64Hash);
-  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(password), { name: 'PBKDF2' }, false, ['deriveBits']);
-  const bits = await crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt, iterations }, key, expected.byteLength * 8);
-  const got = new Uint8Array(bits);
-  if (got.length !== expected.length) return false;
-  let diff = 0; for (let i = 0; i < got.length; i++) diff |= got[i] ^ expected[i];
-  return diff === 0;
+  if (!Number.isFinite(iterations) || iterations <= 0) {
+    return false;
+  }
+
+  const salt = Buffer.from(b64Salt, 'base64');
+  const expected = Buffer.from(b64Hash, 'base64');
+  if (!salt.length || !expected.length) {
+    return false;
+  }
+
+  const derived = await pbkdf2(password, salt, iterations, expected.length, 'sha256');
+  if (derived.length !== expected.length) {
+    return false;
+  }
+
+  return timingSafeEqual(derived, expected);
+}
+
+async function verifyPassword(hash: string, password: string) {
+  if (isPbkdf2Hash(hash)) {
+    return verifyPbkdf2(hash, password);
+  }
+
+  return argon2.verify(hash, password);
 }
 
 export default async function handler(req: any, res: any) {
-  const cors = {
-    'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'POST, OPTIONS',
-    'access-control-allow-headers': 'content-type',
-  };
+  applyCors(res);
+
   if (req.method === 'OPTIONS') {
-    return res.status(200)
-      .setHeader('Access-Control-Allow-Origin', cors['access-control-allow-origin'])
-      .setHeader('Access-Control-Allow-Methods', cors['access-control-allow-methods'])
-      .setHeader('Access-Control-Allow-Headers', cors['access-control-allow-headers'])
-      .end();
-  }
-  if (req.method !== 'POST') return res.status(405).json({ error: 'Method Not Allowed' });
-
-  const { email, password } = req.body ?? {};
-  if (!email || !password) return res.status(400).json({ error: 'Missing credentials' });
-
-  const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
-  const { data: row, error } = await supabase
-    .from('judges')
-    .select('*')
-    .eq('email', email)
-    .maybeSingle();
-
-  if (error) {
-    console.error('DB error', error);
-    return res.status(500).json({ error: 'DB error' });
+    return res.status(200).end();
   }
 
-  if (!row || !row.password_hash) {
-    console.warn('No password_hash for user', email, row);
-    return res.status(401).json({ error: 'Invalid credentials' });
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
   }
 
-  if (typeof row.password_hash !== 'string') {
-    console.error('Unexpected password_hash type for user', email, row.password_hash);
-    return res.status(500).json({ error: 'Server password config error' });
+  const { email, password, devicePublicKey } = req.body ?? {};
+
+  if (typeof email !== 'string' || typeof password !== 'string') {
+    return res.status(400).json({ error: 'Missing credentials' });
   }
 
-  const ok = await verifyPbkdf2(password, row.password_hash);
+  const normalizedEmail = email.trim();
 
-  if (!ok) return res.status(401).json({ error: 'Invalid credentials' });
+  try {
+    const { data: judge, error: judgeError } = await supabase
+      .from('judges')
+      .select('*')
+      .ilike('email', normalizedEmail)
+      .limit(1)
+      .maybeSingle();
 
-  // TODO: vytvoř a vrať vlastní session/JWT
-  return res.status(200)
-    .setHeader('Content-Type', 'application/json')
-    .json({ id: row.id, must_change_password: row.must_change_password });
+    if (judgeError) {
+      console.error('DB error while loading judge', judgeError);
+      return res.status(500).json({ error: 'DB error' });
+    }
+
+    if (!judge || typeof judge.password_hash !== 'string' || !judge.password_hash.length) {
+      console.warn('No password_hash for user', normalizedEmail, judge);
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+
+    let passwordOk = false;
+    try {
+      passwordOk = await verifyPassword(judge.password_hash, password);
+    } catch (error) {
+      console.error('Failed to verify password', error);
+      return res.status(500).json({ error: 'Failed to verify credentials' });
+    }
+
+    if (!passwordOk) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+
+    if (judge.must_change_password) {
+      return res.status(200).json({ id: judge.id, must_change_password: true, email: judge.email });
+    }
+
+    const { data: assignment, error: assignmentError } = await supabase
+      .from('judge_assignments')
+      .select('*')
+      .eq('judge_id', judge.id)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (assignmentError) {
+      console.error('Failed to load assignment for judge', judge.id, assignmentError);
+      return res.status(500).json({ error: 'Judge has no assignment' });
+    }
+
+    if (!assignment) {
+      return res.status(403).json({ error: 'Judge has no assignment' });
+    }
+
+    const [{ data: station }, { data: event }] = await Promise.all([
+      supabase
+        .from('stations')
+        .select('id, code, name')
+        .eq('id', assignment.station_id)
+        .maybeSingle(),
+      supabase
+        .from('events')
+        .select('id, name')
+        .eq('id', assignment.event_id)
+        .maybeSingle(),
+    ]);
+
+    if (!station || !event) {
+      return res.status(500).json({ error: 'Failed to resolve assignment details' });
+    }
+
+    const { data: patrolsData, error: patrolsError } = await supabase
+      .from('patrols')
+      .select('id, team_name, category, sex, patrol_code')
+      .eq('event_id', assignment.event_id)
+      .eq('active', true)
+      .order('patrol_code', { ascending: true });
+
+    if (patrolsError) {
+      console.error('Failed to load patrols', patrolsError);
+      return res.status(500).json({ error: 'Failed to load patrols' });
+    }
+
+    const manifest = {
+      judge: {
+        id: judge.id,
+        email: judge.email,
+        displayName: judge.display_name,
+      },
+      station: {
+        id: station.id,
+        code: station.code,
+        name: station.name,
+      },
+      event: {
+        id: event.id,
+        name: event.name,
+      },
+      allowedCategories: assignment.allowed_categories ?? [],
+      allowedTasks: assignment.allowed_tasks ?? [],
+      manifestVersion: 1,
+    };
+
+    const patrols = (patrolsData ?? []) as Array<{
+      id: string;
+      team_name: string;
+      category: string;
+      sex: string;
+      patrol_code: string;
+    }>;
+
+    const sessionId = randomToken(16);
+    const deviceSalt = randomToken(24);
+    const refreshToken = createRefreshToken({
+      sub: judge.id,
+      stationId: station.id,
+      sessionId,
+      eventId: event.id,
+    });
+    const accessToken = createAccessToken({
+      sub: judge.id,
+      stationId: station.id,
+      sessionId,
+      eventId: event.id,
+    });
+
+    const refreshTokenHash = hashRefreshToken(refreshToken);
+    const refreshExpiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_SECONDS * 1000);
+
+    const { error: sessionError } = await supabase.from('judge_sessions').insert({
+      id: sessionId,
+      judge_id: judge.id,
+      station_id: station.id,
+      device_salt: deviceSalt,
+      public_key: typeof devicePublicKey === 'string' && devicePublicKey.length ? devicePublicKey : null,
+      manifest_version: manifest.manifestVersion,
+      refresh_token_hash: refreshTokenHash,
+      refresh_token_expires_at: toIso(refreshExpiresAt),
+    });
+
+    if (sessionError) {
+      console.error('Failed to initialise session', sessionError);
+      return res.status(500).json({ error: 'Failed to initialise session' });
+    }
+
+    return res.status(200).json({
+      access_token: accessToken,
+      access_token_expires_in: ACCESS_TOKEN_TTL_SECONDS,
+      refresh_token: refreshToken,
+      refresh_token_expires_in: REFRESH_TOKEN_TTL_SECONDS,
+      device_salt: deviceSalt,
+      manifest,
+      patrols,
+    });
+  } catch (error) {
+    console.error('Unexpected error during login', error);
+    return res.status(500).json({ error: 'Unexpected error' });
+  }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,8 @@
         "@supabase/supabase-js": "^2.57.4",
         "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.3",
+        "argon2": "^0.43.0",
+        "jsonwebtoken": "^9.0.2",
         "localforage": "^1.10.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -2482,6 +2484,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.35",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.35.tgz",
@@ -3676,6 +3687,21 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argon2": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.43.1.tgz",
+      "integrity": "sha512-TfOzvDWUaQPurCT1hOwIeFNkgrAJDpbBGBGWDgzDsm11nNhImc13WhdGdCU6K7brkp8VpeY07oGtSex0Wmhg8w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "node-addon-api": "^8.4.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3901,6 +3927,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -4386,6 +4418,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ejs": {
@@ -6181,6 +6222,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6263,11 +6359,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lodash.sortby": {
@@ -6389,7 +6527,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6417,6 +6554,26 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.21",
@@ -7091,7 +7248,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,8 @@
     "@supabase/supabase-js": "^2.57.4",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
+    "argon2": "^0.43.0",
+    "jsonwebtoken": "^9.0.2",
     "localforage": "^1.10.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"


### PR DESCRIPTION
## Summary
- replace the Vercel auth login API stub with the full session, manifest, and token issuing logic
- support PBKDF2 and Argon2 password verification and persist judge sessions in Supabase
- add argon2 and jsonwebtoken dependencies for the serverless login implementation

## Testing
- npm --prefix web run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc0694c56c8326a2c8e3692aeac4f6