### PR TITLE
Adjust web routing to use /setonuv-zavod paths

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -75,6 +75,7 @@ const QUEUE_KEY_PREFIX = 'web_pending_ops_v1';
 const LEGACY_QUEUE_KEY_PREFIX = 'web_pending_station_submissions_v1';
 
 import { env } from './envVars';
+import { getStationPath, isStationAppPath } from './routing';
 
 const isAdminMode =
   typeof env.VITE_ADMIN_MODE === 'string' && ['1', 'true', 'yes', 'on'].includes(env.VITE_ADMIN_MODE.toLowerCase());
@@ -463,7 +464,7 @@ function StationApp({ auth, refreshManifest }: { auth: AuthenticatedState; refre
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const desiredPath = `/stations/${encodeURIComponent(stationId)}`;
+      const desiredPath = getStationPath(stationId);
       if (window.location.pathname !== desiredPath) {
         window.history.replaceState({}, '', desiredPath + window.location.search + window.location.hash);
       }
@@ -1655,10 +1656,9 @@ export function useStationRouting(status: AuthStatus) {
         return;
       }
 
-      const canonicalPath = `/stations/${stationId}`;
-      const altPath = `/stanoviste/${stationId}`;
+      const canonicalPath = getStationPath(stationId);
 
-      if (pathname !== canonicalPath && pathname !== altPath) {
+      if (pathname !== canonicalPath) {
         window.history.replaceState(window.history.state, '', `${canonicalPath}${search}${hash}`);
       }
       return;
@@ -1670,7 +1670,7 @@ export function useStationRouting(status: AuthStatus) {
       status.state === 'password-change-required' ||
       status.state === 'error'
     ) {
-      if (/^\/(?:stations|stanoviste)\//i.test(pathname)) {
+      if (isStationAppPath(pathname)) {
         window.history.replaceState(window.history.state, '', '/');
       }
     }

--- a/web/src/__tests__/stationRouting.test.tsx
+++ b/web/src/__tests__/stationRouting.test.tsx
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type { AuthStatus } from '../auth/types';
+import { getStationPath } from '../routing';
 
 let useStationRouting: (status: AuthStatus) => void;
 
@@ -43,7 +44,7 @@ describe('useStationRouting', () => {
 
     rerender({ status: stationStatus });
 
-    expect(window.location.pathname).toBe('/stations/station-123');
+    expect(window.location.pathname).toBe(getStationPath('station-123'));
   });
 
   it('clears station path when returning to login', () => {
@@ -73,7 +74,7 @@ describe('useStationRouting', () => {
       initialProps: { status: stationStatus },
     });
 
-    expect(window.location.pathname).toBe('/stations/station-123');
+    expect(window.location.pathname).toBe(getStationPath('station-123'));
 
     rerender({ status: unauthStatus });
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import { AuthProvider } from './auth/context';
 import { registerSW } from 'virtual:pwa-register';
 import zelenaLigaLogo from './assets/znak_SPTO_transparent.png';
+import { isScoreboardPathname } from './routing';
 
 function applyBranding() {
   if (document.title !== 'Zelena liga') {
@@ -41,7 +42,7 @@ applyBranding();
 const params = new URLSearchParams(window.location.search);
 const view = params.get('view');
 const pathname = window.location.pathname;
-const isScoreboardPath = /^\/scoreboard(?:\b|\/)/i.test(pathname);
+const isScoreboardPath = isScoreboardPathname(pathname);
 
 function render(element: React.ReactNode) {
   root.render(

--- a/web/src/routing.ts
+++ b/web/src/routing.ts
@@ -1,0 +1,30 @@
+export const ROUTE_PREFIX = '/setonuv-zavod';
+export const STATION_ROUTE_PREFIX = `${ROUTE_PREFIX}/station`;
+export const SCOREBOARD_ROUTE_PREFIX = `${ROUTE_PREFIX}/scoreboard`;
+
+const LEGACY_STATION_PREFIXES = ['/stations', '/stanoviste'];
+const LEGACY_SCOREBOARD_PREFIXES = ['/scoreboard'];
+
+export function getStationPath(stationId: string): string {
+  return `${STATION_ROUTE_PREFIX}/${encodeURIComponent(stationId)}`;
+}
+
+export function isStationAppPath(pathname: string): boolean {
+  if (pathname === STATION_ROUTE_PREFIX || pathname.startsWith(`${STATION_ROUTE_PREFIX}/`)) {
+    return true;
+  }
+
+  return LEGACY_STATION_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function isScoreboardPathname(pathname: string): boolean {
+  if (pathname === SCOREBOARD_ROUTE_PREFIX || pathname.startsWith(`${SCOREBOARD_ROUTE_PREFIX}/`)) {
+    return true;
+  }
+
+  return LEGACY_SCOREBOARD_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -13,6 +13,22 @@
       "destination": "https://vdkbdnxkpeeqxnruwiah.supabase.co/functions/v1/$1"
     },
     {
+      "source": "/setonuv-zavod/station",
+      "destination": "/"
+    },
+    {
+      "source": "/setonuv-zavod/station/(.*)",
+      "destination": "/"
+    },
+    {
+      "source": "/setonuv-zavod/scoreboard",
+      "destination": "/"
+    },
+    {
+      "source": "/setonuv-zavod/scoreboard/(.*)",
+      "destination": "/"
+    },
+    {
       "source": "/stations/(.*)",
       "destination": "/"
     },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
+import { ROUTE_PREFIX, STATION_ROUTE_PREFIX } from './src/routing';
 
 export default defineConfig({
   plugins: [
@@ -18,8 +19,8 @@ export default defineConfig({
         theme_color: '#0b5d44',
         background_color: '#0b5d44',
         display: 'standalone',
-        scope: '/',
-        start_url: '/',
+        scope: `${ROUTE_PREFIX}/`,
+        start_url: STATION_ROUTE_PREFIX,
         lang: 'cs',
         icons: [
           {


### PR DESCRIPTION
## Summary
- add shared routing helpers to load the station and scoreboard views under /setonuv-zavod
- update the station app routing logic, Vercel rewrites, and PWA config for the new base paths

## Testing
- npx vitest run src/__tests__/stationRouting.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc1306e9488326bac5497113802bfe