### PR TITLE
Drop stale offline queue entries from previous sessions

### DIFF
--- a/web/src/__tests__/stationFlow.test.tsx
+++ b/web/src/__tests__/stationFlow.test.tsx
@@ -542,6 +542,57 @@ describe('station workflow', () => {
     expect(storedQueue).toBeNull();
   });
 
+  it('removes submissions from previous sessions before syncing', async () => {
+    const staleOperation = {
+      id: 'op-stale-session',
+      type: 'submission' as const,
+      payload: {
+        event_id: 'event-test',
+        station_id: 'station-test',
+        patrol_id: 'patrol-stale',
+        category: 'N',
+        arrived_at: new Date('2024-03-01T09:00:00Z').toISOString(),
+        wait_minutes: 3,
+        points: 5,
+        judge: 'Test Judge',
+        note: 'Stará relace',
+        useTargetScoring: false,
+        normalizedAnswers: null,
+        shouldDeleteQuiz: true,
+        patrol_code: 'N-98',
+        team_name: 'Lišky',
+        sex: 'F',
+        finish_time: null,
+        judge_id: 'judge-test',
+        session_id: 'other-session',
+        manifest_version: 1,
+      },
+      signature: 'stale-signature',
+      signature_payload: '{}',
+      created_at: new Date('2024-03-01T09:00:00Z').toISOString(),
+      inProgress: false,
+      retryCount: 0,
+      nextAttemptAt: Date.now(),
+    };
+
+    await localforage.setItem(QUEUE_KEY, [staleOperation]);
+
+    await renderApp();
+
+    await waitFor(() => expect(screen.getByText('Skener hlídek')).toBeInTheDocument());
+    await waitFor(() => expect(fetchMock).not.toHaveBeenCalled());
+
+    const alerts = await screen.findAllByText(
+      'Odebrán 1 záznam z dřívější relace – nelze jej odeslat.',
+    );
+    expect(alerts.length).toBeGreaterThanOrEqual(1);
+
+    await waitFor(async () => {
+      const storedQueue = await localforage.getItem(QUEUE_KEY);
+      expect(storedQueue).toBeNull();
+    });
+  });
+
   it('flushes queued target quiz submission via sync endpoint', async () => {
     const pendingOperation = {
       id: 'op-target-sync',


### PR DESCRIPTION
## Summary
- filter the offline sync queue so submissions from different events, stations, sessions or manifest versions are removed before attempting to sync
- surface a user alert when such stale items are discarded to explain why they disappeared from the queue
- add a regression test that verifies stale operations are dropped without calling the sync endpoint

## Testing
- `npm test -- --run`
- `npx vitest run src/__tests__/stationFlow.test.tsx`
- `npx vitest run src/__tests__/stationRouting.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68dc1b218964832690f72a22ccaae7fa