### PR TITLE
Fix sync endpoint routing for offline submissions

### DIFF
--- a/server/src/sync.ts
+++ b/server/src/sync.ts
@@ -151,7 +151,7 @@ async function processSubmission(
   return <OperationResult>{ id: operation.id, status: 'done' };
 }
 
-syncRouter.post('/sync', async (req: Request, res: Response) => {
+async function handleSyncRequest(req: Request, res: Response) {
   const authHeader = req.header('authorization');
   if (!authHeader?.startsWith('Bearer ')) {
     return res.status(401).json({ error: 'Missing token' });
@@ -250,8 +250,10 @@ syncRouter.post('/sync', async (req: Request, res: Response) => {
       results.push({ id: operation.id, status: 'failed', error: message });
     }
   }
-
   res.json({ results });
-});
+}
+
+syncRouter.post('/sync', handleSyncRequest);
+syncRouter.post('/auth/sync', handleSyncRequest);
 
 export default syncRouter;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -772,7 +772,7 @@ function StationApp({ auth, refreshManifest }: { auth: AuthenticatedState; refre
     }
 
     try {
-      const response = await fetch(`${baseUrl}/sync`, {
+      const response = await fetch(`${baseUrl}/auth/sync`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- allow the sync handler to respond to both `/sync` and `/auth/sync`
- point the web client at `/auth/sync` so submissions reach proxied deployments

## Testing
- npm test (web)


------
https://chatgpt.com/codex/tasks/task_e_68dc23d225bc8326b0caea51d912479b