### PR TITLE
Ensure pending queue retries after backoff

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1249,6 +1249,24 @@ function StationApp({ auth, refreshManifest }: { auth: AuthenticatedState; refre
     return new Date(earliest).toISOString();
   }, [pendingItems]);
 
+  useEffect(() => {
+    if (!nextAttemptAtIso) {
+      return undefined;
+    }
+
+    const targetTime = new Date(nextAttemptAtIso).getTime();
+    if (!Number.isFinite(targetTime)) {
+      return undefined;
+    }
+
+    const delay = Math.max(0, targetTime - Date.now());
+    const timeout = window.setTimeout(() => {
+      void syncQueue();
+    }, delay);
+
+    return () => window.clearTimeout(timeout);
+  }, [nextAttemptAtIso, syncQueue]);
+
   const timeOnCourse = useMemo(() => {
     if (!startTime || !finishAt) {
       return null;


### PR DESCRIPTION
## Summary
- schedule a retry of the offline submission queue when the next attempt becomes due so queued records resume syncing automatically after a backoff

## Testing
- npx vitest run src/__tests__/stationFlow.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc5e7b6b1c832692594eba992fbfe2