### PR TITLE
Add logout button to station header

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -73,6 +73,22 @@ body {
   gap: 16px;
 }
 
+.hero-actions {
+  display: flex;
+  align-items: center;
+}
+
+.hero-actions .logout-button {
+  background: rgba(255, 255, 255, 0.18);
+  color: #0b5346;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  box-shadow: 0 16px 30px rgba(10, 78, 56, 0.28);
+}
+
+.hero-actions .logout-button:hover {
+  background: rgba(255, 255, 255, 0.28);
+}
+
 .station-summary {
   display: flex;
   flex-direction: column;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -267,7 +267,15 @@ function waitSecondsToMinutes(seconds: number) {
   return Math.max(0, Math.round(seconds / 60));
 }
 
-function StationApp({ auth, refreshManifest }: { auth: AuthenticatedState; refreshManifest: () => Promise<void> }) {
+function StationApp({
+  auth,
+  refreshManifest,
+  logout,
+}: {
+  auth: AuthenticatedState;
+  refreshManifest: () => Promise<void>;
+  logout: () => Promise<void>;
+}) {
   const manifest = auth.manifest;
   const eventId = manifest.event.id;
   const stationId = manifest.station.id;
@@ -1025,6 +1033,10 @@ function StationApp({ auth, refreshManifest }: { auth: AuthenticatedState; refre
     }
   }, [answersInput, useTargetScoring, patrol, categoryAnswers]);
 
+  const handleLogout = useCallback(() => {
+    void logout();
+  }, [logout]);
+
   const saveCategoryAnswers = useCallback(async () => {
     if (!stationId) {
       pushAlert('Vyber prosím stanoviště před uložením odpovědí.');
@@ -1364,6 +1376,11 @@ function StationApp({ auth, refreshManifest }: { auth: AuthenticatedState; refre
             nextAttemptAt={nextAttemptAtIso}
             lastSyncedAt={lastSavedAt}
           />
+          <div className="hero-actions">
+            <button type="button" className="logout-button" onClick={handleLogout}>
+              Odhlásit se
+            </button>
+          </div>
         </div>
       </header>
 
@@ -1810,7 +1827,7 @@ export function useStationRouting(status: AuthStatus) {
 }
 
 function App() {
-  const { status, refreshManifest } = useAuth();
+  const { status, refreshManifest, logout } = useAuth();
 
   useStationRouting(status);
 
@@ -1857,7 +1874,7 @@ function App() {
   }
 
   if (status.state === 'authenticated') {
-    return <StationApp auth={status} refreshManifest={refreshManifest} />;
+    return <StationApp auth={status} refreshManifest={refreshManifest} logout={logout} />;
   }
 
   return null;


### PR DESCRIPTION
## Summary
- add a logout button to the station header and wire it to the auth context
- style the new control so it fits the existing hero section

## Testing
- npm test -- --run src/__tests__/stationFlow.test.tsx --reporter=verbose
- npm test -- --run src/__tests__/stationRouting.test.tsx --reporter=verbose

------
https://chatgpt.com/codex/tasks/task_e_68dc61449e2483269da77659f7ca47c7