### PR TITLE
Adjust ticket queue button layout and manual entry alignment

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -692,8 +692,12 @@ textarea {
 .manual-entry {
   display: flex;
   gap: 16px;
-  align-items: flex-end;
+  align-items: flex-start;
   flex-wrap: wrap;
+}
+
+.manual-entry button {
+  align-self: flex-start;
 }
 
 .manual-entry input {
@@ -1409,6 +1413,12 @@ textarea {
   gap: 0.5rem;
 }
 
+.ticket-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .ticket-meta > span {
   font-variant-numeric: tabular-nums;
 }
@@ -1429,6 +1439,10 @@ textarea {
   .ticket-meta {
     flex-direction: row;
     align-items: center;
+  }
+
+  .ticket-actions {
+    flex-direction: column;
   }
 
   .ticket-meta button {

--- a/web/src/components/TicketQueue.tsx
+++ b/web/src/components/TicketQueue.tsx
@@ -87,12 +87,14 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
                   </div>
                   <div className="ticket-meta">
                     <span>{formatDuration(waitMs)}</span>
-                    <button type="button" onClick={() => onChangeState(ticket.id, 'serving')}>
-                      Obsluhovat
-                    </button>
-                    <button type="button" onClick={() => onChangeState(ticket.id, 'paused')}>
-                      Pozastavit
-                    </button>
+                    <div className="ticket-actions">
+                      <button type="button" onClick={() => onChangeState(ticket.id, 'serving')}>
+                        Obsluhovat
+                      </button>
+                      <button type="button" onClick={() => onChangeState(ticket.id, 'paused')}>
+                        Pozastavit
+                      </button>
+                    </div>
                   </div>
                 </li>
               );
@@ -115,12 +117,14 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
                   </div>
                   <div className="ticket-meta">
                     <span>{formatDuration(serveMs)}</span>
-                    <button type="button" onClick={() => onChangeState(ticket.id, 'done')}>
-                      Hotovo
-                    </button>
-                    <button type="button" onClick={() => onChangeState(ticket.id, 'paused')}>
-                      Pozastavit
-                    </button>
+                    <div className="ticket-actions">
+                      <button type="button" onClick={() => onChangeState(ticket.id, 'done')}>
+                        Hotovo
+                      </button>
+                      <button type="button" onClick={() => onChangeState(ticket.id, 'paused')}>
+                        Pozastavit
+                      </button>
+                    </div>
                   </div>
                 </li>
               );


### PR DESCRIPTION
## Summary
- align the manual patrol-loading button with the manual entry field
- keep ticket queue pause actions stacked below the primary action for better stability

## Testing
- [ ] Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dce8b9bea08326a6449f5b7879c023