### PR TITLE
Add time scoring helper and surface calculated finish points

### DIFF
--- a/web/src/__tests__/stationFlow.test.tsx
+++ b/web/src/__tests__/stationFlow.test.tsx
@@ -86,6 +86,11 @@ vi.mock('../supabaseClient', () => {
       case 'station_passages':
         return {
           upsert: () => Promise.resolve({ error: new Error('Offline') }),
+          select: () => ({
+            eq: () => ({
+              eq: () => Promise.resolve({ data: [], error: null }),
+            }),
+          }),
         };
       case 'station_scores':
         return {

--- a/web/src/__tests__/timeScoring.test.ts
+++ b/web/src/__tests__/timeScoring.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { computePureCourseSeconds, computeTimePoints, isTimeScoringCategory } from '../timeScoring';
+
+describe('timeScoring', () => {
+  it('identifies valid categories', () => {
+    expect(isTimeScoringCategory('N')).toBe(true);
+    expect(isTimeScoringCategory('m')).toBe(false);
+    expect(isTimeScoringCategory(' X ')).toBe(false);
+    expect(isTimeScoringCategory(undefined)).toBe(false);
+  });
+
+  it('computes pure course seconds with midnight rollover and wait', () => {
+    const start = new Date('2024-06-01T21:30:00Z');
+    const finish = new Date('2024-06-02T00:05:30Z');
+    const result = computePureCourseSeconds({ start, finish, waitMinutes: 15 });
+    expect(result).toBe(8430);
+  });
+
+  it('returns 12 points at or under category limit', () => {
+    expect(computeTimePoints('N', 110 * 60)).toBe(12);
+    expect(computeTimePoints('N', 90 * 60)).toBe(12);
+    expect(computeTimePoints('n', 100 * 60)).toBe(12);
+  });
+
+  it('applies one point penalty for each started 10 minutes over limit', () => {
+    expect(computeTimePoints('M', 121 * 60)).toBe(11);
+    expect(computeTimePoints('M', 129 * 60)).toBe(11);
+    expect(computeTimePoints('M', 130 * 60)).toBe(11);
+    expect(computeTimePoints('M', 131 * 60)).toBe(10);
+  });
+
+  it('returns null for unsupported categories or missing time', () => {
+    expect(computeTimePoints('X', 1000)).toBeNull();
+    expect(computeTimePoints('N', null)).toBeNull();
+  });
+});

--- a/web/src/timeScoring.ts
+++ b/web/src/timeScoring.ts
@@ -1,0 +1,60 @@
+export type TimeScoringCategory = 'N' | 'M' | 'S' | 'R';
+
+const CATEGORY_TIME_LIMITS_MINUTES: Record<TimeScoringCategory, number> = {
+  N: 110,
+  M: 120,
+  S: 130,
+  R: 140,
+};
+
+const CATEGORY_KEYS: readonly TimeScoringCategory[] = ['N', 'M', 'S', 'R'] as const;
+
+export function isTimeScoringCategory(value: string | null | undefined): value is TimeScoringCategory {
+  if (!value) {
+    return false;
+  }
+  return CATEGORY_KEYS.includes(value as TimeScoringCategory);
+}
+
+export function computePureCourseSeconds({
+  start,
+  finish,
+  waitMinutes = 0,
+}: {
+  start: Date;
+  finish: Date;
+  waitMinutes?: number;
+}): number {
+  let ms = finish.getTime() - start.getTime();
+  if (!Number.isFinite(ms)) {
+    return 0;
+  }
+  if (ms < 0) {
+    ms += 24 * 60 * 60 * 1000;
+  }
+  const waitMs = Number.isFinite(waitMinutes) ? Math.max(0, waitMinutes) * 60 * 1000 : 0;
+  const pureMs = Math.max(0, ms - waitMs);
+  return Math.round(pureMs / 1000);
+}
+
+export function computeTimePoints(
+  category: string | null | undefined,
+  pureSeconds: number | null | undefined,
+): number | null {
+  const normalized = typeof category === 'string' ? category.trim().toUpperCase() : '';
+  if (!isTimeScoringCategory(normalized) || pureSeconds === null || pureSeconds === undefined) {
+    return null;
+  }
+  if (!Number.isFinite(pureSeconds)) {
+    return null;
+  }
+  const safeSeconds = Math.max(0, Number(pureSeconds));
+  const limitMinutes = CATEGORY_TIME_LIMITS_MINUTES[normalized];
+  const limitSeconds = limitMinutes * 60;
+  const overSeconds = safeSeconds - limitSeconds;
+  if (overSeconds <= 0) {
+    return 12;
+  }
+  const penaltySteps = Math.ceil(overSeconds / (10 * 60));
+  return 12 - penaltySteps;
+}


### PR DESCRIPTION
## Summary
- add a reusable time scoring utility that computes pure course duration and points from the category limits
- extend the finish station workflow to load wait times, show pure time, and display the computed time score alongside guidance
- cover the new logic with unit tests and update existing mocks for the additional Supabase call

## Testing
- npm test -- run

------
https://chatgpt.com/codex/tasks/task_e_68dce71dfccc8326851baa286d17ae79