### PR TITLE
Streamline patrol queue wait tracking

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -599,30 +599,16 @@ textarea {
   gap: 18px;
 }
 
-.scanner-icon {
-  width: 92px;
-  height: 92px;
-  border-radius: 26px;
-  background: #fff4e5;
-  color: #d97706;
-  display: grid;
-  place-items: center;
-  font-size: 40px;
-}
-
-.scanner-copy h2 {
-  margin: 0;
-}
-
-.scanner-copy p {
-  margin: 6px 0 0;
-  color: #6b5c50;
-}
-
 .scanner-wrapper {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.scanner-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .scanner-controls {
@@ -895,10 +881,10 @@ textarea {
   font-size: 20px;
 }
 
-.wait-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+.wait-hint {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin: 4px 0 0;
 }
 
 .error-text {
@@ -1383,10 +1369,6 @@ textarea {
 
 .ticket-serving {
   border: 2px solid rgba(56, 189, 248, 0.6);
-}
-
-.ticket-paused {
-  border: 2px dashed rgba(148, 163, 184, 0.6);
 }
 
 .ticket-done {

--- a/web/src/__tests__/stationFlow.test.tsx
+++ b/web/src/__tests__/stationFlow.test.tsx
@@ -690,7 +690,7 @@ describe('station workflow', () => {
     await user.type(screen.getByPlaceholderText('např. NH-15'), 'N-01');
     await user.click(screen.getByRole('button', { name: 'Načíst hlídku' }));
 
-    const quickAddButton = await screen.findByRole('button', { name: 'Přidat do fronty' });
+    const quickAddButton = await screen.findByRole('button', { name: 'Čekat' });
 
     await user.click(quickAddButton);
 

--- a/web/src/components/TicketQueue.tsx
+++ b/web/src/components/TicketQueue.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { Ticket } from '../auth/tickets';
-import { computeServeTime, computeWaitTime } from '../auth/tickets';
+import { computeWaitTime } from '../auth/tickets';
 
 interface TicketQueueProps {
   tickets: Ticket[];
@@ -28,7 +28,6 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
     const waiting: Ticket[] = [];
     const serving: Ticket[] = [];
     const done: Ticket[] = [];
-    const paused: Ticket[] = [];
 
     tickets.forEach((ticket) => {
       switch (ticket.state) {
@@ -38,9 +37,6 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
         case 'serving':
           serving.push(ticket);
           break;
-        case 'paused':
-          paused.push(ticket);
-          break;
         case 'done':
           done.push(ticket);
           break;
@@ -49,7 +45,7 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
       }
     });
 
-    return { waiting, serving, done, paused };
+    return { waiting, serving, done };
   }, [tickets, heartbeat]);
 
   const nextUp = grouped.waiting[0];
@@ -91,9 +87,6 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
                       <button type="button" onClick={() => onChangeState(ticket.id, 'serving')}>
                         Obsluhovat
                       </button>
-                      <button type="button" onClick={() => onChangeState(ticket.id, 'paused')}>
-                        Pozastavit
-                      </button>
                     </div>
                   </div>
                 </li>
@@ -108,7 +101,7 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
           </div>
           <ul>
             {grouped.serving.map((ticket) => {
-              const serveMs = computeServeTime(ticket);
+              const waitMs = computeWaitTime(ticket);
               return (
                 <li key={ticket.id} className="ticket ticket-serving">
                   <div>
@@ -116,40 +109,15 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
                     <span>{ticket.teamName}</span>
                   </div>
                   <div className="ticket-meta">
-                    <span>{formatDuration(serveMs)}</span>
+                    <span>{waitMs > 0 ? formatDuration(waitMs) : '—'}</span>
                     <div className="ticket-actions">
                       <button type="button" onClick={() => onChangeState(ticket.id, 'done')}>
                         Hotovo
                       </button>
-                      <button type="button" onClick={() => onChangeState(ticket.id, 'paused')}>
-                        Pozastavit
+                      <button type="button" onClick={() => onChangeState(ticket.id, 'waiting')}>
+                        Čekat
                       </button>
                     </div>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-        <div className="tickets-column">
-          <div className="tickets-column-header">
-            <h3>Pozastavené</h3>
-            <span>{grouped.paused.length}</span>
-          </div>
-          <ul>
-            {grouped.paused.map((ticket) => {
-              const waitMs = computeWaitTime(ticket);
-              return (
-                <li key={ticket.id} className="ticket ticket-paused">
-                  <div>
-                    <strong>{ticket.patrolCode}</strong>
-                    <span>{ticket.teamName}</span>
-                  </div>
-                  <div className="ticket-meta">
-                    <span>{formatDuration(waitMs)}</span>
-                    <button type="button" onClick={() => onChangeState(ticket.id, 'waiting')}>
-                      Čeká dál
-                    </button>
                   </div>
                 </li>
               );
@@ -163,7 +131,7 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
           </div>
           <ul>
             {grouped.done.map((ticket) => {
-              const serveMs = computeServeTime(ticket);
+              const waitMs = computeWaitTime(ticket);
               return (
                 <li key={ticket.id} className="ticket ticket-done">
                   <div>
@@ -171,7 +139,7 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
                     <span>{ticket.teamName}</span>
                   </div>
                   <div className="ticket-meta">
-                    <span>{formatDuration(serveMs)}</span>
+                    <span>{waitMs > 0 ? formatDuration(waitMs) : '—'}</span>
                   </div>
                 </li>
               );


### PR DESCRIPTION
## Summary
- capture queue wait durations for patrols and use them automatically in the station form instead of manual timers
- refresh the scanner panel with a card header, dedicated serve/wait actions, and show the queue after the scanner
- simplify ticket queue states by removing the paused state, migrating stored tickets, and updating the queue UI

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dcf78e19e083268efaf62416e080d1