### PR TITLE
Add rewrite rule for auth sync endpoint

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -5,6 +5,10 @@
       "destination": "/api/auth/login"
     },
     {
+      "source": "/auth/sync",
+      "destination": "/api/auth/sync"
+    },
+    {
       "source": "/auth/change-password",
       "destination": "/api/auth/change-password"
     },


### PR DESCRIPTION
## Summary
- route `/auth/sync` requests through Vercel to the serverless API endpoint so queued submissions can sync successfully

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd0193e38c83268616cb1c2c733a24