### PR TITLE
Handle queue tickets without manifest data

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -460,6 +460,7 @@ function StationApp({
           patrolCode,
           teamName: patrol.team_name,
           category: patrol.category,
+          sex: patrol.sex,
           initialState,
         });
         addedState = newTicket.state;
@@ -826,17 +827,26 @@ function StationApp({
 
       if (nextState === 'done' && updated) {
         const summary = patrolById.get(updated.patrolId);
-        if (!summary) {
+        const ticketPatrol: Patrol = summary
+          ? {
+              id: summary.id,
+              team_name: summary.team_name,
+              category: summary.category,
+              sex: summary.sex,
+              patrol_code: summary.patrol_code || updated.patrolCode || null,
+            }
+          : {
+              id: updated.patrolId,
+              team_name: updated.teamName,
+              category: updated.category,
+              sex: updated.sex,
+              patrol_code: updated.patrolCode || null,
+            };
+
+        if (!ticketPatrol.team_name) {
           pushAlert('Hlídku se nepodařilo otevřít, není v manifestu.');
           return;
         }
-        const ticketPatrol: Patrol = {
-          id: summary.id,
-          team_name: summary.team_name,
-          category: summary.category,
-          sex: summary.sex,
-          patrol_code: summary.patrol_code || updated.patrolCode || null,
-        };
         const waitSeconds = Math.max(0, Math.round(updated.waitAccumMs / 1000));
         initializeFormForPatrol(ticketPatrol, {
           arrivedAt: updated.createdAt,

--- a/web/src/auth/tickets.ts
+++ b/web/src/auth/tickets.ts
@@ -9,6 +9,7 @@ export interface Ticket {
   patrolCode: string;
   teamName: string;
   category: string;
+  sex: string;
   state: TicketState;
   createdAt: string;
   waitStartedAt?: string;
@@ -34,6 +35,7 @@ function sanitizeTicket(raw: StoredTicket): Ticket {
     patrolCode: raw.patrolCode,
     teamName: raw.teamName,
     category: raw.category,
+    sex: typeof raw.sex === 'string' ? raw.sex : '',
     state,
     createdAt: raw.createdAt,
     waitStartedAt,
@@ -69,6 +71,7 @@ export function createTicket(data: {
   patrolCode: string;
   teamName: string;
   category: string;
+  sex: string;
   initialState?: TicketState;
 }): Ticket {
   const now = new Date().toISOString();
@@ -79,6 +82,7 @@ export function createTicket(data: {
     patrolCode: data.patrolCode,
     teamName: data.teamName,
     category: data.category,
+    sex: data.sex,
     state,
     createdAt: now,
     waitStartedAt: state === 'waiting' ? now : undefined,


### PR DESCRIPTION
## Summary
- persist patrol sex information on queue tickets so completed entries retain metadata offline
- fall back to ticket data when moving completed queue items into the station form if the manifest entry is missing

## Testing
- npm test -- --run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68dd015746f4832687d84a45804baefa