### PR TITLE
docs: update README and add user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pro generování QR kódů.
 ## Přehled repozitáře
 
 - `web/` – webová aplikace pro rozhodčí a výsledkový přehled (React, Vite,
-  TypeScript).
+  TypeScript, PWA se service workerem).
 - `supabase/sql/` – schéma databáze, pohledy, RLS politiky a referenční seed.
 - `google-sheets/` – Apps Script pro import hlídek a popis šablony tabulky.
 - `scripts/` – nástroje pro generování QR kódů hlídek.
@@ -58,16 +58,21 @@ Server poskytuje endpointy:
 ### Hlavní funkce
 
 - Skenování QR kódů hlídek kamerou zařízení (ZXing) nebo ruční zadání kódu.
-- Formulář pro zápis bodů, čekací doby a poznámky ke stanovišti.
+- Formulář pro zápis bodů, čekací doby, poznámky a času doběhu (včetně
+  výpočtu penalizace za časové kategorie).
 - Automatické vyhodnocení terčového úseku včetně přepínače mezi manuálním a
-  automatickým režimem.
-- Editace a přehled správných odpovědí pro jednotlivé kategorie včetně tabulky.
+  automatickým režimem a validace vstupu.
+- Správa správných odpovědí pro jednotlivé kategorie s možností editace v
+  administrátorském režimu a přehledem uložených terčových výsledků.
+- Lokální fronta hlídek (čekají/obsluhované/hotové) pro řízení provozu
+  stanoviště, navázaná na skenování hlídky.
 - Offline fronta neodeslaných záznamů uložená v IndexedDB (`localforage`) s
-  náhledem a ruční synchronizací.
-- Přehled posledních výsledků s napojením na Supabase Realtime a detail terče.
-- Report terčových odpovědí s exportem do CSV.
-- Samostatný výsledkový přehled pro kancelář postavený na pohledech Supabase
-  `results` a `results_ranked` (stačí přidat `?view=scoreboard` do URL).
+  automatickými pokusy o synchronizaci a ručním přehledem.
+- Přehled posledních výsledků s napojením na Supabase Realtime, detailní
+  náhled terčových odpovědí a rychlé opravy bodů ostatních stanovišť.
+- Report terčových odpovědí s exportem do CSV a historie skenování pro audit.
+- Samostatný výsledkový přehled (scoreboard) pro kancelář s automatickým
+  obnovováním a exportem do XLSX.
 
 ### Instalace a spuštění
 
@@ -84,6 +89,8 @@ Server poskytuje endpointy:
    VITE_SUPABASE_URL=<url z projektu Supabase>
    VITE_SUPABASE_ANON_KEY=<anon klíč>
    VITE_EVENT_ID=<UUID aktuální akce>
+   # doporučeno: předvyplněné stanoviště pro bypass režim a přesměrování URL
+   VITE_STATION_ID=<UUID stanoviště>
    # volitelné: zapne administrátorský režim pro editaci správných odpovědí
    VITE_ADMIN_MODE=1
    # adresa backendu pro login/manifest (pokud běží samostatně)
@@ -116,22 +123,33 @@ Server poskytuje endpointy:
 
 - Stejné prostředí (`.env`) jako pro rozhodčí – je potřeba především
   `VITE_EVENT_ID`.
-- Při spuštění aplikace přidej do URL parametr `?view=scoreboard`. Dynamicky se
-  načte stránka s tabulkami z pohledů `results` a `results_ranked`.
+- Výsledkový přehled je dostupný na URL
+  `/setonuv-zavod/scoreboard` (nebo přidáním `?view=scoreboard` k libovolné
+  URL aplikace). Dynamicky se načte stránka s tabulkami z pohledů `results` a
+  `results_ranked`.
 - Stránka se automaticky obnovuje každých 30 sekund, případně lze použít ruční
   tlačítko „Aktualizovat“.
+- Lze exportovat kompletní výsledky do XLSX souboru – stačí kliknout na
+  tlačítko „Exportovat Excel“.
 
 ### Další poznámky
 
 - Offline fronta je per prohlížeč/stanici – při ztrátě sítě se záznamy ukládají
-  lokálně a po kliknutí na „Odeslat nyní“ (nebo po návratu připojení)
-  synchronizují.
+  lokálně, aplikace je průběžně zkouší odesílat a zobrazuje čas dalšího pokusu.
+  Ručně lze synchronizaci vyvolat z detailu fronty.
 - Zadané jméno rozhodčího se ukládá do `localStorage` pro další relaci.
 - Správné odpovědi lze hromadně upravit v horním panelu (vyžaduje administrátorský
   režim). Při zapnutí automatického hodnocení se odpovědi validují (12 otázek,
   pouze písmena A–D).
 - Každé stanoviště má vlastní URL tvaru `/stations/<station_id>` (alias `/stanoviste/<station_id>`);
-  pro scoreboard existuje krátká adresa `/scoreboard`.
+  aktuálně probíhající instalace je dostupná i na prefixu `/setonuv-zavod`.
+  Pro scoreboard existuje krátká adresa `/scoreboard` a zkrácený přepis
+  `/setonuv-zavod/scoreboard`.
+
+## Uživatelský manuál
+
+Detailní návod pro rozhodčí i kancelář je v souboru
+[`docs/USER_GUIDE.cs.md`](./docs/USER_GUIDE.cs.md).
 
 ## Supabase & Google Sheets
 

--- a/docs/USER_GUIDE.cs.md
+++ b/docs/USER_GUIDE.cs.md
@@ -1,0 +1,122 @@
+# Uživatelský manuál – Seton Scoring App
+
+Tento dokument popisuje aktuální chování webové aplikace pro rozhodčí
+stanovišť Setonu a samostatný výsledkový přehled (scoreboard). Cílem je poskytnout
+praktický návod pro provoz na stanovišti i pro kancelář závodu.
+
+## 1. Přístup a přihlášení
+
+1. Otevři adresu nasazené aplikace. Aplikace běží jako PWA a po prvním načtení
+   funguje i bez připojení.
+2. Zadej e-mail a heslo rozhodčího. Přístupové údaje spravuje hlavní rozhodčí.
+3. Volitelně můžeš při přihlášení nastavit vlastní PIN (4–6 číslic). PIN se uloží
+   jen lokálně do prohlížeče a umožní zařízení odemknout bez zadávání hesla.
+4. Pokud systém vyžaduje změnu hesla, zobrazí se formulář pro zadání nového.
+   Po uložení se přihlášení dokončí automaticky.
+5. Po úspěšném přihlášení aplikace stáhne manifest (údaje o stanovišti,
+   rozhodčím a seznam hlídek) a uloží je lokálně. Při dalším startu lze zařízení
+   odemknout zadáním PINu, i když je offline.
+
+## 2. Orientace v rozhraní stanoviště
+
+- Horní lišta zobrazuje informace o stanovišti, rozhodčím a stavu synchronizace.
+  Ikona offline fronty indikuje, kolik záznamů čeká na odeslání a kdy proběhne
+  další pokus.
+- Tlačítko **Odhlásit se** zruší lokální data a vrátí aplikaci na přihlašovací
+  obrazovku.
+- Notifikace se objevují v horní části hlavního sloupce a po několika sekundách
+  mizí.
+
+## 3. Běžný pracovní postup na stanovišti
+
+1. **Příprava hlídky**
+   - Naskenuj QR kód hlídky vestavěným skenerem nebo zadej kód ručně.
+   - Pokud QR kód chybí, aplikace přiřadí dočasný kód `TMP-###`, který se uloží
+     jen pro aktuální relaci.
+   - Po naskenování se hlídka zobrazí v hlavičce formuláře, načte se její
+     kategorie a otevře se formulář.
+
+2. **Fronta hlídek**
+   - Skenovanou hlídku můžeš přidat do fronty tlačítkem *Přidat do fronty*.
+   - Fronta má tři stavy: **Čekají**, **Obsluhované** a **Hotové**. Přepínání mezi
+     stavy slouží k evidenci čekacích dob a pořadí.
+   - Fronta se ukládá lokálně pro každé zařízení. Tlačítkem *Resetovat frontu*
+     ji lze vymazat (např. při změně směny).
+
+3. **Vyplnění formuláře**
+   - **Čas příjezdu / čekací doba**: stanoviště eviduje čas naskenování a podle
+     fronty umí předvyplnit čekání. Hodnotu lze ručně upravit.
+   - **Body**: pro běžná stanoviště zadej ručně 0–12 bodů. Pro terčový úsek
+     aktivuj automatické hodnocení (viz níže).
+   - **Poznámka**: libovolný text pro kancelář nebo rozhodčí.
+   - **Čas doběhu**: stanoviště „T“ zobrazuje kalkulačku času – zadej čas doběhu
+     ve formátu HH:MM, aplikace dopočítá čistý čas po odečtení čekání a body za
+     rychlost podle kategorie.
+
+4. **Terčový úsek**
+   - Při zapnutém automatickém hodnocení zadej odpovědi ve formátu `A B C …`.
+     Aplikace kontroluje správný počet (12) a automaticky spočítá body.
+   - Administrátoři mohou v panelu *Správné odpovědi* aktualizovat klíče pro
+     jednotlivé kategorie. Změny se uloží do Supabase.
+
+5. **Uložení záznamu**
+   - Klikni na **Uložit záznam**. Při úspěchu se zobrazí potvrzení a formulář se
+     resetuje.
+   - Pokud je zařízení offline, záznam se uloží do lokální fronty. Banner „Čeká
+     na odeslání“ ukazuje stav, počet pokusů a poslední chybu. Tlačítkem
+     **Odeslat nyní** lze synchronizaci vyvolat ručně.
+
+6. **Kontrola výsledků**
+   - Sekce *Kontrola bodů stanovišť* zobrazuje body hlídky ze všech stanovišť.
+     Po odškrtnutí „OK“ je řádek potvrzen; v případě potřeby lze hodnotu upravit
+     a uložit přímo do Supabase.
+   - *Poslední výsledky* načítají streamovaná data ze Supabase – vhodné pro
+     rychlou kontrolu, zda se záznam skutečně propsal.
+   - Stanoviště „T“ má navíc *Report terčových odpovědí* s filtrem podle hlídek a
+     exportem do CSV.
+
+## 4. Offline režim
+
+- Aplikace funguje i bez připojení; všechny formuláře, fronta hlídek i seznam
+  hlídek zůstávají dostupné.
+- Odesílání probíhá na pozadí. Pokud selže, u záznamu se zobrazí poslední chyba
+  a čas dalšího pokusu. Po obnovení připojení systém synchronizaci spustí
+  automaticky.
+- Offline data jsou vázána na konkrétní prohlížeč a stanoviště. Po odhlášení se
+  fronta i PIN odstraní.
+
+## 5. Scoreboard (kancelář)
+
+1. Otevři `/setonuv-zavod/scoreboard` (nebo přidej `?view=scoreboard` za hlavní
+   URL).
+2. Stránka zobrazí název závodu, čas poslední aktualizace a tabulky pro každou
+   kategorii (N/M/S/R × H/D). Zobrazeny jsou celkové body, body bez trestů a
+   čistý čas.
+3. Data se obnovují automaticky každých 30 sekund. Tlačítko **Aktualizovat**
+   vyvolá načtení okamžitě.
+4. Kliknutím na **Exportovat Excel** stáhneš XLSX soubor se samostatným listem
+   pro každou kategorii, včetně pořadí a čísel hlídek.
+
+## 6. Řešení potíží
+
+- **Nejde se přihlásit** – zkontroluj internetové připojení a správnost hesla.
+  Po více neúspěšných pokusech požádej správce o reset hesla.
+- **Aplikace vyžaduje PIN** – byl nastaven při přihlášení. Pokud ho neznáš,
+  odhlaš zařízení (tlačítko „Odhlásit se“) a přihlas se znovu heslem.
+- **Hlídka se nenajde** – ověř, že QR kód je správný. Lze vyhledat i ručně podle
+  kódu. Pokud hlídka v manifestu není, kontaktuj kancelář.
+- **Záznam se neodeslal** – otevři detail offline fronty, zkontroluj hlášení
+  chyby a zkus **Odeslat nyní**. Při opakovaném selhání zkontroluj konfiguraci
+  Supabase nebo API.
+- **Scoreboard je prázdný** – ověř, že je nastaveno `VITE_EVENT_ID` a že v
+  databázi existují data v pohledech `results` a `results_ranked`.
+
+## 7. Další tipy
+
+- Manifest stanoviště se každých pět minut automaticky obnovuje. Pokud se změní
+  přiřazení rozhodčího nebo hlídek, promítne se do aplikace bez nutnosti reloadu.
+- Číselník hlídek se načítá při startu. Po zásahu kanceláře lze stránku ručně
+  načíst znovu (F5) – uložené offline záznamy zůstanou zachovány.
+- Při zobrazení na tabletu lze aplikaci přidat na plochu. Prohlížeč pak běží v
+  celoobrazovkovém režimu a používá uložený PIN.
+


### PR DESCRIPTION
## Summary
- refresh README to match the current web app implementation, including queue management, offline sync, and scoreboard access
- document the XLSX export button label and add a link to the new user guide
- add a Czech end-user manual covering login, scoring workflow, offline mode, and the scoreboard

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dd19bb3ee88326a21f9d89bbec8878