### PR TITLE
Align scoreboard and auth screens with station styling

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1165,9 +1165,9 @@ textarea {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #0f172a, #1e293b);
-  padding: 2rem;
-  color: #e2e8f0;
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.5rem, 4vw, 3rem);
+  background: linear-gradient(180deg, #f4efe6 0%, #f7f2eb 32%, #fefcf8 100%);
+  color: #2f2a25;
 }
 
 .auth-overlay {
@@ -1177,28 +1177,107 @@ textarea {
   height: 100%;
   z-index: 1000;
   pointer-events: auto;
+  background: linear-gradient(160deg, rgba(13, 124, 84, 0.86), rgba(11, 93, 68, 0.86));
+  backdrop-filter: blur(6px);
+}
+
+.auth-layout {
+  width: min(960px, 100%);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  align-items: stretch;
+}
+
+.auth-hero {
+  background: linear-gradient(160deg, #0d7c54 0%, #0b5d44 60%, #0a4e38 100%);
+  color: #fffdf7;
+  border-radius: clamp(1.5rem, 4vw, 2rem);
+  padding: clamp(2rem, 5vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+  box-shadow: 0 28px 70px rgba(10, 56, 41, 0.28);
+}
+
+.auth-hero-logo {
+  width: 90px;
+  height: 90px;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.12);
+  display: grid;
+  place-items: center;
+  padding: 12px;
+  box-shadow: 0 18px 34px rgba(15, 118, 110, 0.28);
+}
+
+.auth-hero-logo img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.auth-hero-eyebrow {
+  display: inline-block;
+  font-size: 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.auth-hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4.5vw, 2.6rem);
+  letter-spacing: 0.01em;
+}
+
+.auth-hero p {
+  margin: 0;
+  font-size: clamp(1rem, 2.2vw, 1.1rem);
+  color: rgba(255, 255, 255, 0.82);
+  line-height: 1.5;
+}
+
+.auth-hero-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.auth-hero-list li::marker {
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .auth-card {
-  background: rgba(15, 23, 42, 0.88);
-  border-radius: 24px;
-  padding: 2.5rem 2.25rem;
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: clamp(1.5rem, 4vw, 2rem);
+  padding: clamp(2rem, 4.5vw, 2.75rem);
   width: min(420px, 100%);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  box-shadow: 0 40px 120px rgba(15, 23, 42, 0.65);
+  box-shadow: 0 24px 60px rgba(15, 118, 110, 0.18);
+  border: 1px solid rgba(11, 83, 70, 0.08);
+  backdrop-filter: blur(4px);
 }
 
-.auth-card h1 {
+.auth-card h1,
+.auth-card h2 {
   margin: 0;
-  font-size: clamp(1.8rem, 4vw, 2.3rem);
+  font-size: clamp(1.6rem, 4vw, 2.1rem);
+  color: #0b3d33;
 }
 
 .auth-description {
   margin: 0;
-  font-size: 0.95rem;
-  color: #cbd5f5;
+  font-size: 0.98rem;
+  color: rgba(11, 83, 70, 0.75);
+  line-height: 1.5;
 }
 
 .auth-field {
@@ -1208,44 +1287,47 @@ textarea {
 }
 
 .auth-field span {
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.85);
+  font-weight: 600;
+  color: rgba(11, 83, 70, 0.7);
 }
 
 .auth-field input {
   appearance: none;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(11, 83, 70, 0.22);
   border-radius: 0.9rem;
   padding: 0.75rem 1rem;
-  background: rgba(15, 23, 42, 0.6);
-  color: #e2e8f0;
-  caret-color: #e2e8f0;
+  background: rgba(255, 255, 255, 0.95);
+  color: #0b3d33;
+  caret-color: #0b3d33;
   font-size: 1rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .auth-field input::placeholder {
-  color: rgba(148, 163, 184, 0.65);
+  color: rgba(11, 83, 70, 0.45);
 }
 
 .auth-field input:-webkit-autofill,
 .auth-field input:-webkit-autofill:hover,
 .auth-field input:-webkit-autofill:focus {
-  -webkit-text-fill-color: #e2e8f0;
-  -webkit-box-shadow: 0 0 0px 1000px rgba(15, 23, 42, 0.6) inset;
+  -webkit-text-fill-color: #0b3d33;
+  -webkit-box-shadow: 0 0 0px 1000px rgba(255, 255, 255, 0.95) inset;
   transition: background-color 5000s ease-in-out 0s;
 }
 
 .auth-field input:focus {
   outline: none;
-  border-color: #38bdf8;
+  border-color: rgba(56, 189, 248, 0.8);
   box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
 }
 
 .auth-error {
-  color: #fca5a5;
+  color: #b91c1c;
   margin: 0;
+  font-weight: 600;
 }
 
 .auth-primary {
@@ -1253,21 +1335,23 @@ textarea {
   border: none;
   border-radius: 999px;
   padding: 0.9rem 1.75rem;
-  background: #38bdf8;
-  color: #0f172a;
-  font-weight: 600;
+  background: linear-gradient(135deg, #f59e0b 0%, #f97316 100%);
+  color: #fff9ed;
+  font-weight: 700;
   font-size: 1rem;
   cursor: pointer;
-  transition: transform 0.1s ease, filter 0.2s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
 }
 
 .auth-primary:disabled {
   cursor: default;
-  opacity: 0.75;
+  opacity: 0.7;
+  box-shadow: none;
 }
 
 .auth-primary:not(:disabled):hover {
   filter: brightness(1.05);
+  box-shadow: 0 16px 34px rgba(249, 115, 22, 0.3);
 }
 
 .auth-primary:not(:disabled):active {
@@ -1278,27 +1362,44 @@ textarea {
   appearance: none;
   border-radius: 999px;
   padding: 0.85rem 1.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.45);
-  background: transparent;
-  color: #e2e8f0;
-  font-weight: 500;
+  border: 1px solid rgba(11, 83, 70, 0.2);
+  background: rgba(255, 255, 255, 0.85);
+  color: #0b3d33;
+  font-weight: 600;
   font-size: 1rem;
   cursor: pointer;
   width: 100%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
 }
 
 .auth-secondary:not(:disabled):hover {
-  background: rgba(148, 163, 184, 0.18);
-  border-color: rgba(148, 163, 184, 0.65);
+  background: rgba(11, 83, 70, 0.08);
+  border-color: rgba(11, 83, 70, 0.35);
+  box-shadow: 0 10px 24px rgba(11, 83, 70, 0.12);
 }
 
 .auth-secondary:disabled {
-  opacity: 0.7;
+  opacity: 0.65;
   cursor: default;
+}
+
+@media (max-width: 720px) {
+  .auth-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-hero {
+    text-align: center;
+    align-items: center;
+  }
+
+  .auth-hero-list {
+    align-items: center;
+    padding-left: 1.4rem;
+  }
 }
 
 .tickets-card {

--- a/web/src/auth/ChangePasswordScreen.tsx
+++ b/web/src/auth/ChangePasswordScreen.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useRef, useState } from 'react';
 import { changePasswordRequest } from './api';
 import { useAuth } from './context';
+import zelenaLigaLogo from '../assets/znak_SPTO_transparent.png';
 
 interface Props {
   email: string;
@@ -55,50 +56,68 @@ export default function ChangePasswordScreen({ email, judgeId, pendingPin }: Pro
 
   return (
     <div className="auth-shell">
-      <form className="auth-card" onSubmit={handleSubmit}>
-        <h1>Změna hesla</h1>
-        <p className="auth-description">
-          Účet <strong>{email}</strong> vyžaduje nastavení nového hesla.
-        </p>
+      <div className="auth-layout">
+        <div className="auth-hero">
+          <div className="auth-hero-logo">
+            <img src={zelenaLigaLogo} alt="Logo Zelená liga" />
+          </div>
+          <div className="auth-hero-copy">
+            <span className="auth-hero-eyebrow">Zelená liga</span>
+            <h1>Obnova přístupu</h1>
+            <p>Dokonči změnu hesla a vrať se zpět ke správě stanoviště.</p>
+          </div>
+          <ul className="auth-hero-list">
+            <li>Šifrované uložení přístupových údajů</li>
+            <li>Okamžité přihlášení po úspěšné změně</li>
+            <li>Podpora PINu pro zamčené stanoviště</li>
+          </ul>
+        </div>
 
-        <label className="auth-field">
-          <span>Nové heslo</span>
-          <input
-            type="password"
-            autoComplete="new-password"
-            value={newPassword}
-            onChange={(event) => setNewPassword(event.target.value)}
-            required
-          />
-        </label>
+        <form className="auth-card" onSubmit={handleSubmit}>
+          <h2>Změna hesla</h2>
+          <p className="auth-description">
+            Účet <strong>{email}</strong> vyžaduje nastavení nového hesla.
+          </p>
 
-        <label className="auth-field">
-          <span>Potvrzení hesla</span>
-          <input
-            type="password"
-            autoComplete="new-password"
-            value={confirmPassword}
-            onChange={(event) => setConfirmPassword(event.target.value)}
-            required
-          />
-        </label>
+          <label className="auth-field">
+            <span>Nové heslo</span>
+            <input
+              type="password"
+              autoComplete="new-password"
+              value={newPassword}
+              onChange={(event) => setNewPassword(event.target.value)}
+              required
+            />
+          </label>
 
-        {error ? <p className="auth-error">{error}</p> : null}
+          <label className="auth-field">
+            <span>Potvrzení hesla</span>
+            <input
+              type="password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              required
+            />
+          </label>
 
-        <button type="submit" className="auth-primary" disabled={loading}>
-          {loading ? 'Ukládám…' : 'Nastavit heslo'}
-        </button>
-        <button
-          type="button"
-          className="auth-secondary"
-          onClick={() => {
-            void logout();
-          }}
-          disabled={loading}
-        >
-          Zpět na přihlášení
-        </button>
-      </form>
+          {error ? <p className="auth-error">{error}</p> : null}
+
+          <button type="submit" className="auth-primary" disabled={loading}>
+            {loading ? 'Ukládám…' : 'Nastavit heslo'}
+          </button>
+          <button
+            type="button"
+            className="auth-secondary"
+            onClick={() => {
+              void logout();
+            }}
+            disabled={loading}
+          >
+            Zpět na přihlášení
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/web/src/auth/LoginScreen.tsx
+++ b/web/src/auth/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from './context';
+import zelenaLigaLogo from '../assets/znak_SPTO_transparent.png';
 
 interface Props {
   requirePinOnly?: boolean;
@@ -30,62 +31,86 @@ export default function LoginScreen({ requirePinOnly }: Props) {
     }
   };
 
+  const formTitle = requirePinOnly ? 'Odemknutí stanoviště' : 'Přihlášení rozhodčího';
+  const heroTitle = requirePinOnly ? 'Stanoviště' : 'Rozhodčí';
+  const heroDescription = requirePinOnly
+    ? 'Odemkni uložené stanoviště pomocí PINu a pokračuj i bez připojení.'
+    : 'Spravuj průběh závodu, výsledky a offline frontu přímo ze stanoviště.';
+
   return (
     <div className="auth-shell">
-      <form className="auth-card" onSubmit={handleSubmit}>
-        <h1>{requirePinOnly ? 'Odemknutí stanoviště' : 'Přihlášení rozhodčího'}</h1>
-        {requirePinOnly ? (
-          <p className="auth-description">Zadej PIN pro odemknutí uloženého stanoviště.</p>
-        ) : (
-          <p className="auth-description">Přihlašovací údaje získáš od hlavního rozhodčího.</p>
-        )}
+      <div className="auth-layout">
+        <div className="auth-hero">
+          <div className="auth-hero-logo">
+            <img src={zelenaLigaLogo} alt="Logo Zelená liga" />
+          </div>
+          <div className="auth-hero-copy">
+            <span className="auth-hero-eyebrow">Zelená liga</span>
+            <h1>{heroTitle}</h1>
+            <p>{heroDescription}</p>
+          </div>
+          <ul className="auth-hero-list">
+            <li>Bezpečné přihlášení pro rozhodčí</li>
+            <li>Offline režim se synchronizací fronty</li>
+            <li>Rychlý export výsledků do XLSX</li>
+          </ul>
+        </div>
 
-        {!requirePinOnly ? (
-          <label className="auth-field">
-            <span>E-mail</span>
-            <input
-              type="email"
-              inputMode="email"
-              autoComplete="username"
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
-              required
-            />
-          </label>
-        ) : null}
+        <form className="auth-card" onSubmit={handleSubmit}>
+          <h2>{formTitle}</h2>
+          {requirePinOnly ? (
+            <p className="auth-description">Zadej PIN pro odemknutí uloženého stanoviště.</p>
+          ) : (
+            <p className="auth-description">Přihlašovací údaje získáš od hlavního rozhodčího.</p>
+          )}
 
-        {!requirePinOnly ? (
+          {!requirePinOnly ? (
+            <label className="auth-field">
+              <span>E-mail</span>
+              <input
+                type="email"
+                inputMode="email"
+                autoComplete="username"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+              />
+            </label>
+          ) : null}
+
+          {!requirePinOnly ? (
+            <label className="auth-field">
+              <span>Heslo</span>
+              <input
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                required
+              />
+            </label>
+          ) : null}
+
           <label className="auth-field">
-            <span>Heslo</span>
+            <span>{requirePinOnly ? 'PIN' : 'PIN (volitelné)'}</span>
             <input
               type="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              required
+              inputMode="numeric"
+              pattern="[0-9]*"
+              maxLength={6}
+              value={pin}
+              onChange={(event) => setPin(event.target.value.replace(/[^0-9]/g, ''))}
+              required={requirePinOnly}
             />
           </label>
-        ) : null}
 
-        <label className="auth-field">
-          <span>{requirePinOnly ? 'PIN' : 'PIN (volitelné)'}</span>
-          <input
-            type="password"
-            inputMode="numeric"
-            pattern="[0-9]*"
-            maxLength={6}
-            value={pin}
-            onChange={(event) => setPin(event.target.value.replace(/[^0-9]/g, ''))}
-            required={requirePinOnly}
-          />
-        </label>
+          {error ? <p className="auth-error">{error}</p> : null}
 
-        {error ? <p className="auth-error">{error}</p> : null}
-
-        <button type="submit" disabled={loading} className="auth-primary">
-          {loading ? 'Pracuji…' : requirePinOnly ? 'Odemknout' : 'Přihlásit'}
-        </button>
-      </form>
+          <button type="submit" disabled={loading} className="auth-primary">
+            {loading ? 'Pracuji…' : requirePinOnly ? 'Odemknout' : 'Přihlásit'}
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/web/src/scoreboard/ScoreboardApp.css
+++ b/web/src/scoreboard/ScoreboardApp.css
@@ -1,123 +1,275 @@
-.scoreboard-app {
-  min-height: 100vh;
-  padding: 2rem 4vw 4rem;
-  background: #0f172a;
-  color: #f8fafc;
-  font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
+:root {
+  color-scheme: only light;
+}
+
+* {
   box-sizing: border-box;
 }
 
-.scoreboard-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  gap: 2rem;
-  flex-wrap: wrap;
-}
-
-.scoreboard-header h1 {
+body {
   margin: 0;
-  font-size: clamp(2rem, 4vw, 3rem);
+  background: #f4efe6;
+  font-family: 'Inter', 'SF Pro Display', 'Segoe UI', system-ui, sans-serif;
 }
 
-.scoreboard-subtitle {
-  margin: 0.5rem 0 0;
-  font-size: 0.95rem;
-  color: #cbd5f5;
-}
-
-.scoreboard-subtitle.subtle {
-  color: rgba(203, 213, 225, 0.8);
-}
-
-.scoreboard-subtitle code {
-  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    'Liberation Mono', 'Courier New', monospace;
-  font-size: 0.85rem;
-  color: #fbbf24;
-  background: rgba(15, 23, 42, 0.4);
-  padding: 0.1rem 0.35rem;
-  border-radius: 0.4rem;
-}
-
-.scoreboard-meta {
+.scoreboard-app {
+  min-height: 100vh;
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  background: linear-gradient(180deg, #f4efe6 0%, #f7f2eb 32%, #fefcf8 100%);
+  color: #2f2a25;
+}
+
+.scoreboard-hero {
+  padding: 56px 24px 96px;
+  background: linear-gradient(160deg, #0d7c54 0%, #0b5d44 60%, #0a4e38 100%);
+  color: #fffdf7;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  box-shadow: 0 28px 60px rgba(10, 56, 41, 0.24);
+}
+
+.scoreboard-hero-top {
+  display: flex;
   justify-content: space-between;
-  gap: 1rem;
-  font-size: 0.95rem;
+  align-items: flex-start;
+  gap: 32px;
   flex-wrap: wrap;
 }
 
-.scoreboard-actions {
+.scoreboard-hero-brand {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.scoreboard-hero-logo {
+  width: 96px;
+  height: 96px;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.12);
+  display: grid;
+  place-items: center;
+  padding: 12px;
+  box-shadow: 0 18px 34px rgba(15, 118, 110, 0.28);
+}
+
+.scoreboard-hero-logo img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.scoreboard-hero-eyebrow {
+  display: block;
+  font-size: 12px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.72);
+  margin-bottom: 12px;
+}
+
+.scoreboard-hero-brand h1 {
+  margin: 0;
+  font-size: clamp(32px, 5vw, 40px);
+  letter-spacing: 0.01em;
+}
+
+.scoreboard-hero-description {
+  margin: 8px 0 0;
+  max-width: 460px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.82);
+  line-height: 1.4;
+}
+
+.scoreboard-hero-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   flex-wrap: wrap;
 }
 
 .scoreboard-button {
-  appearance: none;
   border: none;
-  border-radius: 999px;
-  padding: 0.5rem 1.25rem;
-  background: #38bdf8;
-  color: #0f172a;
-  font-weight: 600;
+  border-radius: 18px;
+  padding: 14px 22px;
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   cursor: pointer;
-  transition: transform 0.1s ease, filter 0.2s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease, filter 0.2s ease;
 }
 
 .scoreboard-button:disabled {
-  cursor: default;
-  opacity: 0.7;
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
-.scoreboard-button:not(:disabled):hover {
-  filter: brightness(1.05);
+.scoreboard-button--primary {
+  background: linear-gradient(135deg, #f59e0b 0%, #f97316 100%);
+  color: #fff9ed;
+  box-shadow: 0 16px 28px rgba(249, 115, 22, 0.25);
 }
 
-.scoreboard-button:not(:disabled):active {
+.scoreboard-button--primary:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 34px rgba(249, 115, 22, 0.35);
+}
+
+.scoreboard-button--primary:not(:disabled):active {
+  transform: translateY(0);
+}
+
+.scoreboard-button--ghost {
+  background: rgba(255, 255, 255, 0.16);
+  color: #0b5346;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: 0 16px 30px rgba(10, 78, 56, 0.25);
+}
+
+.scoreboard-button--ghost:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.scoreboard-button--ghost:not(:disabled):active {
   transform: translateY(1px);
 }
 
-.scoreboard-button--secondary {
-  background: rgba(56, 189, 248, 0.16);
-  color: #e0f2fe;
-  border: 1px solid rgba(56, 189, 248, 0.45);
+.scoreboard-hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: stretch;
 }
 
-.scoreboard-button--secondary:not(:disabled):hover {
-  filter: none;
-  background: rgba(56, 189, 248, 0.24);
+.scoreboard-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 220px;
+  padding: 16px 20px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 18px 30px rgba(15, 118, 110, 0.18);
 }
 
-.scoreboard-button--secondary:not(:disabled):active {
-  transform: translateY(1px);
+.scoreboard-summary-label {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.72);
 }
 
-.scoreboard-section {
-  background: rgba(15, 23, 42, 0.65);
-  border-radius: 1.25rem;
-  padding: 1.5rem;
-  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.5);
+.scoreboard-summary strong {
+  font-size: 1.3rem;
+  color: #fffdf7;
 }
 
-.scoreboard-section h2 {
-  margin: 0 0 1rem;
-  font-size: 1.5rem;
+.scoreboard-summary-sub {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.78);
+  max-width: 320px;
+  line-height: 1.4;
+}
+
+.scoreboard-summary-sub code {
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.82em;
+  color: #ffe6b3;
+  background: rgba(11, 83, 70, 0.45);
+  padding: 0.15em 0.45em;
+  border-radius: 0.5em;
+}
+
+.scoreboard-content {
+  margin-top: -72px;
+  padding: 0 24px 72px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .scoreboard-error {
-  background: rgba(220, 38, 38, 0.2);
-  border: 1px solid rgba(248, 113, 113, 0.6);
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  color: #fecaca;
+  background: rgba(220, 38, 38, 0.12);
+  border: 1px solid rgba(220, 38, 38, 0.28);
+  padding: 16px 20px;
+  border-radius: 18px;
+  color: #7f1d1d;
   font-weight: 600;
+  box-shadow: 0 14px 32px rgba(127, 29, 29, 0.18);
+}
+
+.scoreboard-section {
+  background: #ffffff;
+  border-radius: 28px;
+  box-shadow: 0 28px 60px rgba(17, 24, 39, 0.12);
+  padding: 32px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.scoreboard-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.scoreboard-section-header h2 {
+  margin: 0;
+  font-size: 1.75rem;
+  color: #2f2a25;
+}
+
+.scoreboard-section-hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #7d6d60;
+}
+
+.scoreboard-placeholder {
+  padding: 24px;
+  border-radius: 22px;
+  background: rgba(15, 118, 110, 0.08);
+  color: #0f766e;
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.scoreboard-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.scoreboard-group {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92) 0%, rgba(246, 240, 231, 0.92) 100%);
+  border-radius: 22px;
+  padding: 20px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid rgba(15, 118, 110, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+.scoreboard-group h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #0b5346;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .scoreboard-table {
@@ -128,101 +280,96 @@
 
 .scoreboard-table thead th {
   text-align: left;
-  font-size: 0.85rem;
-  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #a5b4fc;
-  padding: 0 0 0.75rem;
+  color: #988c82;
+  padding: 0 0 12px;
 }
 
 .scoreboard-table tbody tr {
-  border-top: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.scoreboard-table tbody tr:first-child {
-  border-top: 2px solid rgba(148, 163, 184, 0.35);
+  border-top: 1px solid rgba(47, 42, 37, 0.08);
 }
 
 .scoreboard-table tbody td {
-  padding: 0.65rem 0;
-  font-size: 1.1rem;
-  vertical-align: middle;
+  padding: 12px 0;
+  font-size: 0.98rem;
+  color: #2f2a25;
+  font-weight: 500;
+}
+
+.scoreboard-table tbody td:first-child {
+  font-weight: 700;
+  color: #0f766e;
+  width: 52px;
+}
+
+.scoreboard-table--compact tbody td {
+  font-size: 0.95rem;
 }
 
 .scoreboard-team {
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 4px;
 }
 
 .scoreboard-team strong {
-  font-size: 1.15rem;
-  color: #f8fafc;
+  font-size: 1.05rem;
+  color: #0b5346;
+  letter-spacing: 0.04em;
 }
 
 .scoreboard-team-meta {
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #94a3b8;
+  color: #988c82;
 }
 
 .scoreboard-team-meta.subtle {
-  color: rgba(148, 163, 184, 0.6);
+  color: rgba(152, 140, 130, 0.6);
 }
 
-.scoreboard-placeholder {
-  padding: 1.5rem;
-  border-radius: 0.75rem;
-  background: rgba(148, 163, 184, 0.12);
-  color: #cbd5f5;
-  text-align: center;
-  font-size: 1.05rem;
-}
-
-.scoreboard-groups {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
-}
-
-.scoreboard-group {
-  background: rgba(30, 41, 59, 0.8);
-  border-radius: 1rem;
-  padding: 1rem 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-
-.scoreboard-group h3 {
-  margin: 0;
-  font-size: 1.1rem;
-  color: #bfdbfe;
-}
-
-.scoreboard-table--compact tbody td {
-  font-size: 1rem;
-}
-
-@media (max-width: 720px) {
-  .scoreboard-app {
-    padding: 1.5rem 1.25rem 3rem;
-    gap: 1.5rem;
+@media (max-width: 900px) {
+  .scoreboard-hero {
+    padding: 48px 20px 88px;
   }
 
-  .scoreboard-meta {
-    width: 100%;
-    justify-content: space-between;
+  .scoreboard-content {
+    margin-top: -64px;
+    padding: 0 20px 64px;
+  }
+}
+
+@media (max-width: 600px) {
+  .scoreboard-hero {
+    padding: 44px 16px 84px;
   }
 
-  .scoreboard-actions {
+  .scoreboard-hero-logo {
+    width: 80px;
+    height: 80px;
+    border-radius: 24px;
+  }
+
+  .scoreboard-hero-actions {
     width: 100%;
-    justify-content: flex-end;
+    justify-content: flex-start;
+  }
+
+  .scoreboard-button {
+    flex: 1 1 100%;
+    width: 100%;
+    text-align: center;
+  }
+
+  .scoreboard-content {
+    margin-top: -56px;
+    padding: 0 16px 56px;
   }
 
   .scoreboard-section {
-    padding: 1.25rem;
+    padding: 28px 20px;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the scoreboard layout with the same green hero header and light background used on the station and login screens
- add branding, refreshed action buttons, and status summaries so the scoreboard matches the rest of the app
- refresh the login and password change screens with the shared hero, logo treatment, and light palette from the station view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd1d0447e88326a8743ef218988a19