### PR TITLE
Auto-focus station form when finishing a patrol

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -333,6 +333,9 @@ function StationApp({
   const lastScanRef = useRef<{ code: string; at: number } | null>(null);
   const tempCodesRef = useRef<Map<string, string>>(new Map());
   const tempCounterRef = useRef(1);
+  const formRef = useRef<HTMLElement | null>(null);
+  const pointsInputRef = useRef<HTMLInputElement | null>(null);
+  const answersInputRef = useRef<HTMLInputElement | null>(null);
   const [isOnline, setIsOnline] = useState(typeof navigator !== 'undefined' ? navigator.onLine : true);
   const [startTime, setStartTime] = useState<string | null>(null);
   const [finishTimeInput, setFinishTimeInput] = useState('');
@@ -672,6 +675,17 @@ function StationApp({
 
       void loadTimingData(data.id);
       void loadScoreReview(data.id);
+
+      if (typeof window !== 'undefined') {
+        window.requestAnimationFrame(() => {
+          formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          if (isTargetStation) {
+            answersInputRef.current?.focus();
+          } else {
+            pointsInputRef.current?.focus();
+          }
+        });
+      }
     },
     [categoryAnswers, clearWait, isTargetStation, loadTimingData, loadScoreReview],
   );
@@ -1866,7 +1880,7 @@ function StationApp({
             onReset={handleResetTickets}
           />
 
-          <section className="card form-card">
+          <section ref={formRef} className="card form-card">
             <header className="card-header">
               <div>
                 <h2>Stanovištní formulář</h2>
@@ -2096,11 +2110,12 @@ function StationApp({
                     <p className="card-hint">Terčový úsek se hodnotí automaticky podle zadaných odpovědí.</p>
                     <label>
                       Odpovědi hlídky ({totalAnswers || '–'})
-                      <input
-                        value={answersInput}
-                        onChange={(event) => setAnswersInput(event.target.value.toUpperCase())}
-                        placeholder="např. A B C D …"
-                      />
+                    <input
+                      ref={answersInputRef}
+                      value={answersInput}
+                      onChange={(event) => setAnswersInput(event.target.value.toUpperCase())}
+                      placeholder="např. A B C D …"
+                    />
                     </label>
                     <p className="auto-score">Správně: {autoScore.correct} / {autoScore.total}</p>
                     {answersError ? <p className="error-text">{answersError}</p> : null}
@@ -2109,6 +2124,7 @@ function StationApp({
                   <label>
                     Body (0 až 12)
                     <input
+                      ref={pointsInputRef}
                       value={points}
                       onChange={(event) => setPoints(event.target.value)}
                       type="number"


### PR DESCRIPTION
## Summary
- scroll the station form into view when a patrol is moved to the done state from the queue
- focus the most relevant input so judges can start entering results immediately for both manual and target scoring stations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd28b0ddbc8326b9265a700eefb5ca