### PR TITLE
Improve readability of station summary cards

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -80,7 +80,7 @@ body {
 
 .hero-actions .logout-button {
   background: rgba(255, 255, 255, 0.18);
-  color: #0b5346;
+  color: #fefce8;
   border: 1px solid rgba(255, 255, 255, 0.24);
   box-shadow: 0 16px 30px rgba(10, 78, 56, 0.28);
 }
@@ -104,17 +104,18 @@ body {
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(11, 83, 70, 0.7);
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .station-summary strong {
   font-size: 1.25rem;
-  color: #0b5346;
+  color: #fefce8;
+  text-shadow: 0 2px 6px rgba(10, 60, 46, 0.4);
 }
 
 .station-summary-sub {
   font-size: 0.9rem;
-  color: rgba(11, 83, 70, 0.68);
+  color: rgba(255, 255, 255, 0.82);
 }
 
 .hero-badges {


### PR DESCRIPTION
## Summary
- lighten the station summary text colors to improve contrast on the dark hero background
- adjust the logout button text color for better readability against its translucent background

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd61d588688326a1cb6f980187357b