### PR TITLE
Show patrol code in scanner preview

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -701,6 +701,41 @@ textarea {
   font-size: 15px;
 }
 
+.scanner-code {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #e2e8f0;
+}
+
+.scanner-code__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.scanner-code__label::after {
+  content: ':';
+  margin-left: 4px;
+  color: #94a3b8;
+}
+
+.scanner-code::after {
+  content: attr(data-code);
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #0f172a;
+}
+
 .scanner-note {
   font-size: 0.85rem;
   color: #475569;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -443,6 +443,8 @@ function StationApp({
     [],
   );
 
+  const previewPatrolCode = patrol ? resolvePatrolCode(patrol) : '';
+
   useEffect(() => {
     let cancelled = false;
 
@@ -1905,6 +1907,17 @@ function StationApp({
               {patrol ? (
                 <div className="scanner-preview">
                   <strong>{patrol.team_name}</strong>
+                  {previewPatrolCode ? (
+                    <span
+                      className="scanner-code"
+                      aria-label={`Kód hlídky ${previewPatrolCode}`}
+                      data-code={previewPatrolCode}
+                    >
+                      <span className="scanner-code__label" aria-hidden="true">
+                        Kód
+                      </span>
+                    </span>
+                  ) : null}
                   <span>
                     {patrol.category}/{patrol.sex}
                   </span>


### PR DESCRIPTION
## Summary
- display the loaded patrol's code directly in the scanner preview with an accessible label
- add styling for the patrol code pill so the code is easy to notice

## Testing
- npx vitest run src/__tests__/stationFlow.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd618d41c88326bbe9d7e6261cd89b