### PR TITLE
Refine scoreboard layout and remove pure time column

### DIFF
--- a/web/src/scoreboard/ScoreboardApp.css
+++ b/web/src/scoreboard/ScoreboardApp.css
@@ -284,7 +284,11 @@ body {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: #988c82;
-  padding: 0 0 12px;
+  padding: 0 10px 12px 0;
+}
+
+.scoreboard-table thead th:last-child {
+  padding-right: 0;
 }
 
 .scoreboard-table tbody tr {
@@ -292,7 +296,7 @@ body {
 }
 
 .scoreboard-table tbody td {
-  padding: 12px 0;
+  padding: 12px 10px 12px 0;
   font-size: 0.98rem;
   color: #2f2a25;
   font-weight: 500;
@@ -302,22 +306,40 @@ body {
   font-weight: 700;
   color: #0f766e;
   width: 52px;
+  text-align: center;
+  padding-left: 0;
 }
 
 .scoreboard-table--compact tbody td {
   font-size: 0.95rem;
 }
 
+.scoreboard-table thead th:nth-child(3),
+.scoreboard-table thead th:nth-child(4),
+.scoreboard-table tbody td:nth-child(3),
+.scoreboard-table tbody td:nth-child(4) {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  padding-right: 0;
+}
+
+.scoreboard-table thead th:nth-child(2),
+.scoreboard-table tbody td:nth-child(2) {
+  padding-right: 12px;
+}
+
 .scoreboard-team {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  align-items: flex-start;
 }
 
 .scoreboard-team strong {
   font-size: 1.05rem;
   color: #0b5346;
   letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
 }
 
 .scoreboard-team-meta {

--- a/web/src/scoreboard/ScoreboardApp.tsx
+++ b/web/src/scoreboard/ScoreboardApp.tsx
@@ -407,7 +407,7 @@ function ScoreboardApp() {
       groupedRanked.forEach((group) => {
         const sheetName = formatCategoryLabel(group.category, group.sex);
         const rows = [
-          ['#', 'Hlídka', 'Tým', 'Body', 'Body bez T', 'Čistý čas'],
+          ['#', 'Hlídka', 'Tým', 'Body', 'Body bez T'],
           ...group.items.map((row) => {
             const displayRank = row.displayRank > 0 ? row.displayRank : row.rankInBracket;
             const fallbackCode = createFallbackPatrolCode(group.category, group.sex, displayRank);
@@ -417,7 +417,6 @@ function ScoreboardApp() {
               row.teamName,
               row.totalPoints ?? '',
               row.pointsNoT ?? '',
-              formatSeconds(row.pureSeconds),
             ];
           }),
         ];
@@ -534,7 +533,6 @@ function ScoreboardApp() {
                         <th>Hlídka</th>
                         <th>Body</th>
                         <th>Body bez T</th>
-                        <th>Čistý čas</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -553,7 +551,6 @@ function ScoreboardApp() {
                             </td>
                             <td>{formatPoints(row.totalPoints)}</td>
                             <td>{formatPoints(row.pointsNoT)}</td>
-                            <td>{formatSeconds(row.pureSeconds)}</td>
                           </tr>
                         );
                       })}


### PR DESCRIPTION
## Summary
- remove the "Čistý čas" column from the scoreboard table and Excel export
- tighten scoreboard table spacing and alignment for a more balanced layout

## Testing
- npm run build
- npm run lint --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68dd73d68c2883269e487d419250344b