### PR TITLE
Show event name in scoreboard and improve export button contrast

### DIFF
--- a/supabase/sql/views.sql
+++ b/supabase/sql/views.sql
@@ -2,6 +2,7 @@
 create or replace view results as
 select
   p.event_id,
+  e.name as event_name,
   p.id as patrol_id,
   p.patrol_code,
   p.team_name,
@@ -16,6 +17,7 @@ select
                      where sp.event_id=p.event_id and sp.patrol_id=p.id),0)
   )::bigint as pure_seconds
 from patrols p
+join events e on e.id = p.event_id
 left join station_scores s on s.patrol_id=p.id and s.event_id=p.event_id
 left join stations st on st.id = s.station_id
 left join timings t on t.event_id=p.event_id and t.patrol_id=p.id

--- a/web/src/scoreboard/ScoreboardApp.css
+++ b/web/src/scoreboard/ScoreboardApp.css
@@ -128,18 +128,21 @@ body {
 }
 
 .scoreboard-button--ghost {
-  background: rgba(255, 255, 255, 0.16);
-  color: #0b5346;
-  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.22);
+  color: #fffdf7;
+  border: 1px solid rgba(255, 255, 255, 0.45);
   box-shadow: 0 16px 30px rgba(10, 78, 56, 0.25);
+  text-shadow: 0 1px 4px rgba(11, 68, 55, 0.35);
 }
 
 .scoreboard-button--ghost:not(:disabled):hover {
-  background: rgba(255, 255, 255, 0.24);
+  background: rgba(255, 255, 255, 0.3);
+  filter: brightness(1.02);
 }
 
 .scoreboard-button--ghost:not(:disabled):active {
   transform: translateY(1px);
+  filter: brightness(0.98);
 }
 
 .scoreboard-hero-meta {


### PR DESCRIPTION
## Summary
- include the event name in the results view so the scoreboard receives it with ranking data
- derive and persist the scoreboard event title from Supabase data with an environment fallback
- adjust the ghost export button styling to improve readability against the hero gradient

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd78a59f84832691badf991c4e4f81