### PR TITLE
Add shared footer across app views

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1199,11 +1199,21 @@ textarea {
 .auth-shell {
   min-height: 100vh;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: clamp(2rem, 6vw, 4rem) clamp(1.5rem, 4vw, 3rem);
   background: linear-gradient(180deg, #f4efe6 0%, #f7f2eb 32%, #fefcf8 100%);
   color: #2f2a25;
+  gap: clamp(1.5rem, 4vw, 2rem);
+}
+
+.auth-shell-content {
+  width: 100%;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .auth-overlay {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import LastScoresList from './components/LastScoresList';
 import TargetAnswersReport from './components/TargetAnswersReport';
 import PatrolCodeInput from './components/PatrolCodeInput';
 import OfflineHealth from './components/OfflineHealth';
+import AppFooter from './components/AppFooter';
 import { supabase } from './supabaseClient';
 import './App.css';
 import zelenaLigaLogo from './assets/znak_SPTO_transparent.png';
@@ -2321,6 +2322,7 @@ function StationApp({
           {isTargetStation ? <TargetAnswersReport eventId={eventId} stationId={stationId} /> : null}
         </>
       </main>
+      <AppFooter />
     </div>
   );
 }
@@ -2370,9 +2372,12 @@ function App() {
   if (status.state === 'loading') {
     return (
       <div className="auth-shell auth-overlay">
-        <div className="auth-card">
-          <h1>Načítám…</h1>
+        <div className="auth-shell-content">
+          <div className="auth-card">
+            <h1>Načítám…</h1>
+          </div>
         </div>
+        <AppFooter variant="dark" />
       </div>
     );
   }
@@ -2380,13 +2385,16 @@ function App() {
   if (status.state === 'error') {
     return (
       <div className="auth-shell auth-overlay">
-        <div className="auth-card">
-          <h1>Nelze načíst aplikaci</h1>
-          <p className="auth-description">{status.message || 'Zkontroluj připojení nebo konfiguraci a zkus to znovu.'}</p>
-          <button type="button" className="auth-primary" onClick={() => window.location.reload()}>
-            Zkusit znovu
-          </button>
+        <div className="auth-shell-content">
+          <div className="auth-card">
+            <h1>Nelze načíst aplikaci</h1>
+            <p className="auth-description">{status.message || 'Zkontroluj připojení nebo konfiguraci a zkus to znovu.'}</p>
+            <button type="button" className="auth-primary" onClick={() => window.location.reload()}>
+              Zkusit znovu
+            </button>
+          </div>
         </div>
+        <AppFooter variant="dark" />
       </div>
     );
   }

--- a/web/src/auth/ChangePasswordScreen.tsx
+++ b/web/src/auth/ChangePasswordScreen.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useRef, useState } from 'react';
 import { changePasswordRequest } from './api';
 import { useAuth } from './context';
 import zelenaLigaLogo from '../assets/znak_SPTO_transparent.png';
+import AppFooter from '../components/AppFooter';
 
 interface Props {
   email: string;
@@ -56,68 +57,71 @@ export default function ChangePasswordScreen({ email, judgeId, pendingPin }: Pro
 
   return (
     <div className="auth-shell">
-      <div className="auth-layout">
-        <div className="auth-hero">
-          <div className="auth-hero-logo">
-            <img src={zelenaLigaLogo} alt="Logo Zelená liga" />
+      <div className="auth-shell-content">
+        <div className="auth-layout">
+          <div className="auth-hero">
+            <div className="auth-hero-logo">
+              <img src={zelenaLigaLogo} alt="Logo Zelená liga" />
+            </div>
+            <div className="auth-hero-copy">
+              <span className="auth-hero-eyebrow">Zelená liga</span>
+              <h1>Obnova přístupu</h1>
+              <p>Dokonči změnu hesla a vrať se zpět ke správě stanoviště.</p>
+            </div>
+            <ul className="auth-hero-list">
+              <li>Šifrované uložení přístupových údajů</li>
+              <li>Okamžité přihlášení po úspěšné změně</li>
+              <li>Podpora PINu pro zamčené stanoviště</li>
+            </ul>
           </div>
-          <div className="auth-hero-copy">
-            <span className="auth-hero-eyebrow">Zelená liga</span>
-            <h1>Obnova přístupu</h1>
-            <p>Dokonči změnu hesla a vrať se zpět ke správě stanoviště.</p>
-          </div>
-          <ul className="auth-hero-list">
-            <li>Šifrované uložení přístupových údajů</li>
-            <li>Okamžité přihlášení po úspěšné změně</li>
-            <li>Podpora PINu pro zamčené stanoviště</li>
-          </ul>
+
+          <form className="auth-card" onSubmit={handleSubmit}>
+            <h2>Změna hesla</h2>
+            <p className="auth-description">
+              Účet <strong>{email}</strong> vyžaduje nastavení nového hesla.
+            </p>
+
+            <label className="auth-field">
+              <span>Nové heslo</span>
+              <input
+                type="password"
+                autoComplete="new-password"
+                value={newPassword}
+                onChange={(event) => setNewPassword(event.target.value)}
+                required
+              />
+            </label>
+
+            <label className="auth-field">
+              <span>Potvrzení hesla</span>
+              <input
+                type="password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                required
+              />
+            </label>
+
+            {error ? <p className="auth-error">{error}</p> : null}
+
+            <button type="submit" className="auth-primary" disabled={loading}>
+              {loading ? 'Ukládám…' : 'Nastavit heslo'}
+            </button>
+            <button
+              type="button"
+              className="auth-secondary"
+              onClick={() => {
+                void logout();
+              }}
+              disabled={loading}
+            >
+              Zpět na přihlášení
+            </button>
+          </form>
         </div>
-
-        <form className="auth-card" onSubmit={handleSubmit}>
-          <h2>Změna hesla</h2>
-          <p className="auth-description">
-            Účet <strong>{email}</strong> vyžaduje nastavení nového hesla.
-          </p>
-
-          <label className="auth-field">
-            <span>Nové heslo</span>
-            <input
-              type="password"
-              autoComplete="new-password"
-              value={newPassword}
-              onChange={(event) => setNewPassword(event.target.value)}
-              required
-            />
-          </label>
-
-          <label className="auth-field">
-            <span>Potvrzení hesla</span>
-            <input
-              type="password"
-              autoComplete="new-password"
-              value={confirmPassword}
-              onChange={(event) => setConfirmPassword(event.target.value)}
-              required
-            />
-          </label>
-
-          {error ? <p className="auth-error">{error}</p> : null}
-
-          <button type="submit" className="auth-primary" disabled={loading}>
-            {loading ? 'Ukládám…' : 'Nastavit heslo'}
-          </button>
-          <button
-            type="button"
-            className="auth-secondary"
-            onClick={() => {
-              void logout();
-            }}
-            disabled={loading}
-          >
-            Zpět na přihlášení
-          </button>
-        </form>
       </div>
+      <AppFooter className="auth-footer" />
     </div>
   );
 }

--- a/web/src/auth/LoginScreen.tsx
+++ b/web/src/auth/LoginScreen.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useAuth } from './context';
 import zelenaLigaLogo from '../assets/znak_SPTO_transparent.png';
+import AppFooter from '../components/AppFooter';
 
 interface Props {
   requirePinOnly?: boolean;
@@ -39,78 +40,81 @@ export default function LoginScreen({ requirePinOnly }: Props) {
 
   return (
     <div className="auth-shell">
-      <div className="auth-layout">
-        <div className="auth-hero">
-          <div className="auth-hero-logo">
-            <img src={zelenaLigaLogo} alt="Logo Zelená liga" />
+      <div className="auth-shell-content">
+        <div className="auth-layout">
+          <div className="auth-hero">
+            <div className="auth-hero-logo">
+              <img src={zelenaLigaLogo} alt="Logo Zelená liga" />
+            </div>
+            <div className="auth-hero-copy">
+              <span className="auth-hero-eyebrow">Zelená liga</span>
+              <h1>{heroTitle}</h1>
+              <p>{heroDescription}</p>
+            </div>
+            <ul className="auth-hero-list">
+              <li>Bezpečné přihlášení pro rozhodčí</li>
+              <li>Offline režim se synchronizací fronty</li>
+              <li>Rychlý export výsledků do XLSX</li>
+            </ul>
           </div>
-          <div className="auth-hero-copy">
-            <span className="auth-hero-eyebrow">Zelená liga</span>
-            <h1>{heroTitle}</h1>
-            <p>{heroDescription}</p>
-          </div>
-          <ul className="auth-hero-list">
-            <li>Bezpečné přihlášení pro rozhodčí</li>
-            <li>Offline režim se synchronizací fronty</li>
-            <li>Rychlý export výsledků do XLSX</li>
-          </ul>
-        </div>
 
-        <form className="auth-card" onSubmit={handleSubmit}>
-          <h2>{formTitle}</h2>
-          {requirePinOnly ? (
-            <p className="auth-description">Zadej PIN pro odemknutí uloženého stanoviště.</p>
-          ) : (
-            <p className="auth-description">Přihlašovací údaje získáš od hlavního rozhodčího.</p>
-          )}
+          <form className="auth-card" onSubmit={handleSubmit}>
+            <h2>{formTitle}</h2>
+            {requirePinOnly ? (
+              <p className="auth-description">Zadej PIN pro odemknutí uloženého stanoviště.</p>
+            ) : (
+              <p className="auth-description">Přihlašovací údaje získáš od hlavního rozhodčího.</p>
+            )}
 
-          {!requirePinOnly ? (
+            {!requirePinOnly ? (
+              <label className="auth-field">
+                <span>E-mail</span>
+                <input
+                  type="email"
+                  inputMode="email"
+                  autoComplete="username"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  required
+                />
+              </label>
+            ) : null}
+
+            {!requirePinOnly ? (
+              <label className="auth-field">
+                <span>Heslo</span>
+                <input
+                  type="password"
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  required
+                />
+              </label>
+            ) : null}
+
             <label className="auth-field">
-              <span>E-mail</span>
-              <input
-                type="email"
-                inputMode="email"
-                autoComplete="username"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                required
-              />
-            </label>
-          ) : null}
-
-          {!requirePinOnly ? (
-            <label className="auth-field">
-              <span>Heslo</span>
+              <span>{requirePinOnly ? 'PIN' : 'PIN (volitelné)'}</span>
               <input
                 type="password"
-                autoComplete="current-password"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                required
+                inputMode="numeric"
+                pattern="[0-9]*"
+                maxLength={6}
+                value={pin}
+                onChange={(event) => setPin(event.target.value.replace(/[^0-9]/g, ''))}
+                required={requirePinOnly}
               />
             </label>
-          ) : null}
 
-          <label className="auth-field">
-            <span>{requirePinOnly ? 'PIN' : 'PIN (volitelné)'}</span>
-            <input
-              type="password"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              maxLength={6}
-              value={pin}
-              onChange={(event) => setPin(event.target.value.replace(/[^0-9]/g, ''))}
-              required={requirePinOnly}
-            />
-          </label>
+            {error ? <p className="auth-error">{error}</p> : null}
 
-          {error ? <p className="auth-error">{error}</p> : null}
-
-          <button type="submit" disabled={loading} className="auth-primary">
-            {loading ? 'Pracuji…' : requirePinOnly ? 'Odemknout' : 'Přihlásit'}
-          </button>
-        </form>
+            <button type="submit" disabled={loading} className="auth-primary">
+              {loading ? 'Pracuji…' : requirePinOnly ? 'Odemknout' : 'Přihlásit'}
+            </button>
+          </form>
+        </div>
       </div>
+      <AppFooter className="auth-footer" />
     </div>
   );
 }

--- a/web/src/components/AppFooter.css
+++ b/web/src/components/AppFooter.css
@@ -1,0 +1,26 @@
+.app-footer {
+  margin-top: auto;
+  width: 100%;
+  padding: 24px 16px;
+  text-align: center;
+  font-size: 0.9rem;
+  color: rgba(11, 83, 70, 0.7);
+  background: rgba(255, 255, 255, 0.72);
+  border-top: 1px solid rgba(11, 83, 70, 0.12);
+  backdrop-filter: blur(6px);
+}
+
+.app-footer--dark {
+  background: rgba(10, 78, 56, 0.85);
+  color: rgba(255, 255, 255, 0.82);
+  border-top-color: rgba(255, 255, 255, 0.18);
+}
+
+.auth-footer {
+  background: rgba(255, 255, 255, 0.6);
+  border-top-color: rgba(11, 83, 70, 0.1);
+}
+
+.scoreboard-footer {
+  background: rgba(255, 255, 255, 0.85);
+}

--- a/web/src/components/AppFooter.tsx
+++ b/web/src/components/AppFooter.tsx
@@ -1,0 +1,20 @@
+import './AppFooter.css';
+
+interface AppFooterProps {
+  className?: string;
+  variant?: 'default' | 'dark';
+}
+
+export default function AppFooter({ className, variant = 'default' }: AppFooterProps) {
+  const classes = ['app-footer'];
+
+  if (variant === 'dark') {
+    classes.push('app-footer--dark');
+  }
+
+  if (className) {
+    classes.push(className);
+  }
+
+  return <footer className={classes.join(' ')}>© 32. PTO Severka a Ševa</footer>;
+}

--- a/web/src/scoreboard/ScoreboardApp.tsx
+++ b/web/src/scoreboard/ScoreboardApp.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as XLSX from 'xlsx';
 import { supabase } from '../supabaseClient';
 import zelenaLigaLogo from '../assets/znak_SPTO_transparent.png';
+import AppFooter from '../components/AppFooter';
 import './ScoreboardApp.css';
 
 interface RawResult {
@@ -564,6 +565,7 @@ function ScoreboardApp() {
           )}
         </section>
       </main>
+      <AppFooter className="scoreboard-footer" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a reusable footer component that displays the requested copyright notice
- integrate the footer across station, scoreboard, and authentication views
- adjust authentication layout spacing to accommodate the new footer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd791668188326b2bf7a4a8259eee6