### PR TITLE
Center scoreboard layout

### DIFF
--- a/web/src/scoreboard/ScoreboardApp.css
+++ b/web/src/scoreboard/ScoreboardApp.css
@@ -28,21 +28,22 @@ body {
   flex-direction: column;
   gap: 32px;
   box-shadow: 0 28px 60px rgba(10, 56, 41, 0.24);
+  align-items: center;
+  text-align: center;
 }
 
 .scoreboard-hero-top {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 32px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
 }
 
 .scoreboard-hero-brand {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 20px;
-  flex-wrap: wrap;
+  gap: 16px;
 }
 
 .scoreboard-hero-logo {
@@ -80,7 +81,7 @@ body {
 
 .scoreboard-hero-description {
   margin: 8px 0 0;
-  max-width: 460px;
+  max-width: 560px;
   font-weight: 500;
   color: rgba(255, 255, 255, 0.82);
   line-height: 1.4;
@@ -89,6 +90,7 @@ body {
 .scoreboard-hero-actions {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 12px;
   flex-wrap: wrap;
 }
@@ -147,6 +149,7 @@ body {
   flex-wrap: wrap;
   gap: 16px;
   align-items: stretch;
+  justify-content: center;
 }
 
 .scoreboard-summary {
@@ -159,6 +162,7 @@ body {
   background: rgba(255, 255, 255, 0.14);
   border: 1px solid rgba(255, 255, 255, 0.18);
   box-shadow: 0 18px 30px rgba(15, 118, 110, 0.18);
+  align-items: center;
 }
 
 .scoreboard-summary-label {
@@ -172,13 +176,15 @@ body {
 .scoreboard-summary strong {
   font-size: 1.3rem;
   color: #fffdf7;
+  text-align: center;
 }
 
 .scoreboard-summary-sub {
   font-size: 0.95rem;
   color: rgba(255, 255, 255, 0.78);
-  max-width: 320px;
+  max-width: 360px;
   line-height: 1.4;
+  text-align: center;
 }
 
 .scoreboard-summary-sub code {
@@ -197,6 +203,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 24px;
+  align-items: center;
 }
 
 .scoreboard-error {
@@ -217,12 +224,16 @@ body {
   display: flex;
   flex-direction: column;
   gap: 24px;
+  width: 100%;
+  max-width: 960px;
 }
 
 .scoreboard-section-header {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  text-align: center;
+  align-items: center;
 }
 
 .scoreboard-section-header h2 {
@@ -235,6 +246,8 @@ body {
   margin: 0;
   font-size: 0.95rem;
   color: #7d6d60;
+  max-width: 520px;
+  text-align: center;
 }
 
 .scoreboard-placeholder {
@@ -377,7 +390,7 @@ body {
 
   .scoreboard-hero-actions {
     width: 100%;
-    justify-content: flex-start;
+    justify-content: center;
   }
 
   .scoreboard-button {


### PR DESCRIPTION
## Summary
- center the scoreboard hero elements and supporting metadata to match the new centered design
- align the scoreboard content sections and hints in the middle with a constrained max width for improved readability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd79a9804483269e1121854e602109