### PR TITLE
Expose public event metadata view for scoreboard

### DIFF
--- a/supabase/sql/views.sql
+++ b/supabase/sql/views.sql
@@ -1,3 +1,14 @@
+-- Public event metadata view for read-only clients
+create or replace view events_public as
+select
+  e.id,
+  e.name,
+  e.starts_at,
+  e.ends_at
+from events e;
+
+grant select on events_public to anon, authenticated;
+
 -- Results view (sum points, sum without 'T', pure time)
 create or replace view results as
 select

--- a/web/src/scoreboard/ScoreboardApp.tsx
+++ b/web/src/scoreboard/ScoreboardApp.tsx
@@ -260,17 +260,17 @@ function ScoreboardApp() {
     (async () => {
       try {
         const { data, error } = await supabase
-          .from('events')
+          .from('events_public')
           .select('name')
           .eq('id', rawEventId)
-          .limit(1);
+          .maybeSingle();
         if (!isMountedRef.current || cancelled) return;
         if (error) {
           console.error('Failed to load event name', error);
           return;
         }
-        const row = Array.isArray(data) && data.length ? data[0] : null;
-        const fetchedName = normaliseText((row as { name?: string | null } | null)?.name ?? null);
+        const row = data as { name?: string | null } | null;
+        const fetchedName = normaliseText(row?.name ?? null);
         if (fetchedName) {
           setEventName(fetchedName);
         }


### PR DESCRIPTION
## Summary
- add an `events_public` view that exposes event metadata with anon read access
- update the scoreboard client to load the event name from the new view so the race title is shown

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd7d63c4e0832691c8fa691bdf6450