### PR TITLE
Add scoreboard view with Supabase event names

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Server poskytuje endpointy:
   `VITE_EVENT_ID`.
 - Výsledkový přehled je dostupný na URL
   `/setonuv-zavod/scoreboard` (nebo přidáním `?view=scoreboard` k libovolné
-  URL aplikace). Dynamicky se načte stránka s tabulkami z pohledů `results` a
-  `results_ranked`.
+  URL aplikace). Dynamicky se načte stránka využívající pohled `scoreboard_view`
+  (postavený nad `results_ranked`).
 - Stránka se automaticky obnovuje každých 30 sekund, případně lze použít ruční
   tlačítko „Aktualizovat“.
 - Lze exportovat kompletní výsledky do XLSX souboru – stačí kliknout na

--- a/docs/USER_GUIDE.cs.md
+++ b/docs/USER_GUIDE.cs.md
@@ -109,7 +109,8 @@ praktický návod pro provoz na stanovišti i pro kancelář závodu.
   chyby a zkus **Odeslat nyní**. Při opakovaném selhání zkontroluj konfiguraci
   Supabase nebo API.
 - **Scoreboard je prázdný** – ověř, že je nastaveno `VITE_EVENT_ID` a že v
-  databázi existují data v pohledech `results` a `results_ranked`.
+  databázi existují data v pohledu `scoreboard_view` (postaveném nad `results`
+  a `results_ranked`).
 
 ## 7. Další tipy
 

--- a/supabase/sql/views.sql
+++ b/supabase/sql/views.sql
@@ -53,3 +53,20 @@ select
     order by r.total_points desc, r.points_no_T desc, r.pure_seconds asc
   ) as rank_in_bracket
 from results r;
+
+-- Scoreboard view (ensures up-to-date event names without duplicating data)
+create or replace view scoreboard_view as
+select
+  r.event_id,
+  e.name as event_name,
+  r.patrol_id,
+  r.patrol_code,
+  r.team_name,
+  r.category,
+  r.sex,
+  r.total_points,
+  r.points_no_T,
+  r.pure_seconds,
+  r.rank_in_bracket
+from results_ranked r
+join events e on e.id = r.event_id;

--- a/web/README.md
+++ b/web/README.md
@@ -23,7 +23,7 @@ VITE_ADMIN_MODE=1
 ```
 
 Spuštěním aplikace s parametrem `?view=scoreboard` v URL se načte výsledkový
-přehled, který využívá pohledy `results` a `results_ranked`.
+přehled, který využívá pohled `scoreboard_view` (stavějící na `results_ranked`).
 
 ## Scripts
 

--- a/web/src/scoreboard/ScoreboardApp.tsx
+++ b/web/src/scoreboard/ScoreboardApp.tsx
@@ -289,7 +289,7 @@ function ScoreboardApp() {
     setRefreshing(true);
     try {
       const { data, error } = await supabase
-        .from('results_ranked')
+        .from('scoreboard_view')
         .select('*')
         .eq('event_id', rawEventId)
         .order('category', { ascending: true })
@@ -528,7 +528,7 @@ function ScoreboardApp() {
             <span className="scoreboard-summary-label">Závod</span>
             <strong>{eventLabel}</strong>
             <span className="scoreboard-summary-sub">
-              Data pochází z tabulky Supabase <code>results_ranked</code>.
+              Data pochází z pohledu Supabase <code>scoreboard_view</code>.
             </span>
           </div>
           <div className="scoreboard-summary">


### PR DESCRIPTION
## Summary
- add a dedicated `scoreboard_view` Supabase view to expose event names without duplicating data
- update the scoreboard frontend and docs to consume the new view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd801cd7488326b02c6280d88420de