### PR TITLE
Use station label in target report exports

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2319,7 +2319,14 @@ function StationApp({
           </section>
 
           <LastScoresList eventId={eventId} stationId={stationId} isTargetStation={isTargetStation} />
-          {isTargetStation ? <TargetAnswersReport eventId={eventId} stationId={stationId} /> : null}
+          {isTargetStation ? (
+            <TargetAnswersReport
+              eventId={eventId}
+              stationId={stationId}
+              stationName={stationDisplayName}
+              stationCode={stationCode}
+            />
+          ) : null}
         </>
       </main>
       <AppFooter />


### PR DESCRIPTION
## Summary
- generate a file-friendly station label from the manifest name and code for target reports
- include the label in the target answers CSV filename instead of the raw station UUID
- pass the station metadata from the main app into the target report component

## Testing
- npm --prefix web run build

------
https://chatgpt.com/codex/tasks/task_e_68dd88ecba248326bfe3fa085e922105