### PR TITLE
Use Czech slugs for results and station URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,14 @@ Server poskytuje endpointy:
    Test `stationFlow.test.tsx` kontroluje offline frontu a náhled čekajících
    záznamů.
 
-### Výsledkový přehled (scoreboard)
+### Výsledkový přehled
 
 - Stejné prostředí (`.env`) jako pro rozhodčí – je potřeba především
   `VITE_EVENT_ID`.
 - Výsledkový přehled je dostupný na URL
-  `/setonuv-zavod/scoreboard` (nebo přidáním `?view=scoreboard` k libovolné
-  URL aplikace). Dynamicky se načte stránka využívající pohled `scoreboard_view`
+  `/setonuv-zavod/vysledky` (nebo přidáním `?view=vysledky` k libovolné URL
+  aplikace; starší parametr `?view=scoreboard` zůstává funkční). Dynamicky se
+  načte stránka využívající pohled `scoreboard_view`
   (postavený nad `results_ranked`).
 - Stránka se automaticky obnovuje každých 30 sekund, případně lze použít ruční
   tlačítko „Aktualizovat“.
@@ -141,10 +142,13 @@ Server poskytuje endpointy:
 - Správné odpovědi lze hromadně upravit v horním panelu (vyžaduje administrátorský
   režim). Při zapnutí automatického hodnocení se odpovědi validují (12 otázek,
   pouze písmena A–D).
-- Každé stanoviště má vlastní URL tvaru `/stations/<station_id>` (alias `/stanoviste/<station_id>`);
+- Každé stanoviště má vlastní URL tvaru
+  `/setonuv-zavod/stanoviste/<station_id>` (s krátkým aliasem
+  `/stanoviste/<station_id>` a zpětně kompatibilním `/stations/<station_id>`);
   aktuálně probíhající instalace je dostupná i na prefixu `/setonuv-zavod`.
-  Pro scoreboard existuje krátká adresa `/scoreboard` a zkrácený přepis
-  `/setonuv-zavod/scoreboard`.
+  Pro výsledkový přehled existuje krátká adresa `/vysledky` a zkrácený přepis
+  `/setonuv-zavod/vysledky` (starší `/scoreboard` a `/setonuv-zavod/scoreboard`
+  zůstávají funkční).
 
 ## Uživatelský manuál
 

--- a/docs/USER_GUIDE.cs.md
+++ b/docs/USER_GUIDE.cs.md
@@ -85,10 +85,10 @@ praktický návod pro provoz na stanovišti i pro kancelář závodu.
 - Offline data jsou vázána na konkrétní prohlížeč a stanoviště. Po odhlášení se
   fronta i PIN odstraní.
 
-## 5. Scoreboard (kancelář)
+## 5. Výsledky (kancelář)
 
-1. Otevři `/setonuv-zavod/scoreboard` (nebo přidej `?view=scoreboard` za hlavní
-   URL).
+1. Otevři `/setonuv-zavod/vysledky` (nebo přidej `?view=vysledky` za hlavní URL;
+   starší parametr `?view=scoreboard` nadále funguje).
 2. Stránka zobrazí název závodu, čas poslední aktualizace a tabulky pro každou
    kategorii (N/M/S/R × H/D). Zobrazeny jsou celkové body, body bez trestů a
    čistý čas.

--- a/web/README.md
+++ b/web/README.md
@@ -22,8 +22,9 @@ VITE_STATION_ID=<UUID stanoviště>
 VITE_ADMIN_MODE=1
 ```
 
-Spuštěním aplikace s parametrem `?view=scoreboard` v URL se načte výsledkový
-přehled, který využívá pohled `scoreboard_view` (stavějící na `results_ranked`).
+Spuštěním aplikace s parametrem `?view=vysledky` v URL se načte výsledkový
+přehled, který využívá pohled `scoreboard_view` (stavějící na `results_ranked`);
+starší parametr `?view=scoreboard` zůstává funkční.
 
 ## Scripts
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -43,6 +43,7 @@ const params = new URLSearchParams(window.location.search);
 const view = params.get('view');
 const pathname = window.location.pathname;
 const isScoreboardPath = isScoreboardPathname(pathname);
+const scoreboardViews = new Set(['scoreboard', 'vysledky']);
 
 function render(element: React.ReactNode) {
   root.render(
@@ -52,7 +53,7 @@ function render(element: React.ReactNode) {
   );
 }
 
-if (view === 'scoreboard' || isScoreboardPath) {
+if ((view && scoreboardViews.has(view)) || isScoreboardPath) {
   import('./scoreboard/ScoreboardApp')
     .then(({ default: ScoreboardApp }) => {
       render(<ScoreboardApp />);

--- a/web/src/routing.ts
+++ b/web/src/routing.ts
@@ -1,9 +1,17 @@
 export const ROUTE_PREFIX = '/setonuv-zavod';
-export const STATION_ROUTE_PREFIX = `${ROUTE_PREFIX}/station`;
-export const SCOREBOARD_ROUTE_PREFIX = `${ROUTE_PREFIX}/scoreboard`;
+export const STATION_ROUTE_PREFIX = `${ROUTE_PREFIX}/stanoviste`;
+export const SCOREBOARD_ROUTE_PREFIX = `${ROUTE_PREFIX}/vysledky`;
 
-const LEGACY_STATION_PREFIXES = ['/stations', '/stanoviste'];
-const LEGACY_SCOREBOARD_PREFIXES = ['/scoreboard'];
+const ADDITIONAL_STATION_PREFIXES = [
+  `${ROUTE_PREFIX}/station`,
+  '/stations',
+  '/stanoviste',
+];
+const ADDITIONAL_SCOREBOARD_PREFIXES = [
+  `${ROUTE_PREFIX}/scoreboard`,
+  '/scoreboard',
+  '/vysledky',
+];
 
 export function getStationPath(stationId: string): string {
   return `${STATION_ROUTE_PREFIX}/${encodeURIComponent(stationId)}`;
@@ -14,7 +22,7 @@ export function isStationAppPath(pathname: string): boolean {
     return true;
   }
 
-  return LEGACY_STATION_PREFIXES.some(
+  return ADDITIONAL_STATION_PREFIXES.some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
   );
 }
@@ -24,7 +32,7 @@ export function isScoreboardPathname(pathname: string): boolean {
     return true;
   }
 
-  return LEGACY_SCOREBOARD_PREFIXES.some(
+  return ADDITIONAL_SCOREBOARD_PREFIXES.some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
   );
 }

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -30,11 +30,27 @@
       "destination": "https://vdkbdnxkpeeqxnruwiah.supabase.co/functions/v1/$1"
     },
     {
+      "source": "/setonuv-zavod/stanoviste",
+      "destination": "/"
+    },
+    {
+      "source": "/setonuv-zavod/stanoviste/(.*)",
+      "destination": "/"
+    },
+    {
       "source": "/setonuv-zavod/station",
       "destination": "/"
     },
     {
       "source": "/setonuv-zavod/station/(.*)",
+      "destination": "/"
+    },
+    {
+      "source": "/setonuv-zavod/vysledky",
+      "destination": "/"
+    },
+    {
+      "source": "/setonuv-zavod/vysledky/(.*)",
       "destination": "/"
     },
     {
@@ -50,7 +66,19 @@
       "destination": "/"
     },
     {
+      "source": "/stanoviste",
+      "destination": "/"
+    },
+    {
       "source": "/stanoviste/(.*)",
+      "destination": "/"
+    },
+    {
+      "source": "/vysledky",
+      "destination": "/"
+    },
+    {
+      "source": "/vysledky/(.*)",
       "destination": "/"
     },
     {


### PR DESCRIPTION
## Summary
- switch the canonical station route to `/setonuv-zavod/stanoviste` while leaving existing slugs as fallbacks
- rename the scoreboard URL to `/setonuv-zavod/vysledky` and update the bootstrap logic and documentation accordingly
- extend the Vercel rewrites and docs with Czech short aliases so legacy links keep working

## Testing
- npm run test -- stationRouting

------
https://chatgpt.com/codex/tasks/task_e_68dd895ecaf08326892b9759fb1a1091