### PR TITLE
Disable queue on station T and simplify patrol labels

### DIFF
--- a/web/src/__tests__/stationFlow.test.tsx
+++ b/web/src/__tests__/stationFlow.test.tsx
@@ -294,8 +294,10 @@ async function loadPatrolAndOpenForm(user: ReturnType<typeof userEvent.setup>, c
   const serveButton = await screen.findByRole('button', { name: 'Obsluhovat' });
   await user.click(serveButton);
 
-  const doneButton = await screen.findByRole('button', { name: 'Hotovo' });
-  await user.click(doneButton);
+  if (mockedStationCode !== 'T') {
+    const doneButton = await screen.findByRole('button', { name: 'Hotovo' });
+    await user.click(doneButton);
+  }
 }
 
 type TableFactory = () => unknown;

--- a/web/src/components/LastScoresList.tsx
+++ b/web/src/components/LastScoresList.tsx
@@ -210,8 +210,9 @@ export function LastScoresList({ eventId, stationId, isTargetStation }: LastScor
                 <div className="score-team-box">
                   <strong>{patrol.team_name}</strong>
                   <span className="score-team-meta">
-                    {patrol.patrol_code ? `${patrol.patrol_code} • ` : ''}
-                    {patrol.category}/{patrol.sex}
+                    {patrol.patrol_code
+                      ? patrol.patrol_code
+                      : `${patrol.category}/${patrol.sex}`}
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- disable the ticket queue workflow on station T while keeping other stations unchanged
- correct the station T display name and standardize patrol metadata to show just the patrol code when available
- update the last scores list and station workflow tests for the new presentation

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dd889b39908326bc3e07d5367fd9de