### PR TITLE
Remove manual refresh from target answers report

### DIFF
--- a/web/src/components/TargetAnswersReport.tsx
+++ b/web/src/components/TargetAnswersReport.tsx
@@ -154,9 +154,6 @@ export default function TargetAnswersReport({
           <p className="card-subtitle">Přehled uložených terčových odpovědí a možnost exportu.</p>
         </div>
         <div className="target-report-actions">
-          <button type="button" onClick={load} disabled={loading}>
-            {loading ? 'Načítám…' : 'Obnovit'}
-          </button>
           <button type="button" onClick={handleExport} disabled={!rows.length}>
             Export CSV
           </button>


### PR DESCRIPTION
## Summary
- remove the manual refresh button from the target answers report so only CSV export remains

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd8dfe8e208326bb4048cdf4d899bb