### PR TITLE
feat: enable scrollable picker wheels

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -284,86 +284,168 @@ body {
   padding: 16px;
 }
 
-.patrol-code-input {
+.patrol-code-input,
+.points-input {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   flex: 1 1 220px;
 }
 
-.patrol-code-input__label {
+.patrol-code-input__label,
+.points-input__label {
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(11, 83, 70, 0.7);
 }
 
-.patrol-code-input__selectors {
+.patrol-code-input__wheel-group,
+.points-input__wheel-group {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
+  gap: 14px;
+  align-items: stretch;
 }
 
-.patrol-code-input__options {
-  display: flex;
-  gap: 8px;
-}
-
-.patrol-code-input__option {
-  appearance: none;
+.patrol-code-input__wheel,
+.points-input__wheel {
+  position: relative;
+  flex: 1 1 0;
+  min-width: 72px;
+  max-height: 220px;
+  --wheel-padding: 72px;
+  padding-block: var(--wheel-padding);
+  padding-inline: 0;
+  border-radius: 20px;
   border: 1px solid rgba(11, 83, 70, 0.24);
-  border-radius: 999px;
-  padding: 8px 14px;
-  font-weight: 600;
-  background: rgba(255, 255, 255, 0.9);
-  color: #0a4236;
-  font-size: 0.9rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  background: rgba(255, 255, 255, 0.92);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scroll-snap-type: y mandatory;
+  scroll-padding-block: var(--wheel-padding);
+  scroll-behavior: smooth;
+  overscroll-behavior-y: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
-.patrol-code-input__option[disabled] {
+.patrol-code-input__wheel::before,
+.points-input__wheel::before {
+  content: '';
+  position: sticky;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 38px;
+  margin: 0 6px;
+  border-radius: 14px;
+  background: rgba(13, 124, 84, 0.12);
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(13, 124, 84, 0.1);
+  z-index: 1;
+}
+
+.patrol-code-input__wheel::after,
+.points-input__wheel::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(255, 255, 255, 0) 25%,
+    rgba(255, 255, 255, 0) 75%,
+    rgba(255, 255, 255, 0.95) 100%
+  );
+  z-index: 2;
+}
+
+.patrol-code-input__wheel[aria-disabled='true'],
+.points-input__wheel[aria-disabled='true'] {
   opacity: 0.4;
   cursor: not-allowed;
 }
 
-.patrol-code-input__option[aria-pressed='true'] {
+.patrol-code-input__wheel-option,
+.points-input__wheel-option {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: rgba(10, 66, 54, 0.8);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  margin: 2px 10px;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  z-index: 3;
+  scroll-snap-align: center;
+  scroll-snap-stop: always;
+}
+
+.patrol-code-input__wheel-option:focus-visible,
+.points-input__wheel-option:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(13, 124, 84, 0.35);
+}
+
+.patrol-code-input__wheel-option:hover,
+.points-input__wheel-option:hover {
+  background: rgba(13, 124, 84, 0.08);
+}
+
+.patrol-code-input__wheel-option--selected,
+.points-input__wheel-option--selected {
   background: #0d7c54;
   color: #fffdf7;
-  border-color: #0b5d44;
-  box-shadow: 0 6px 14px rgba(13, 124, 84, 0.25);
+  box-shadow: 0 8px 18px rgba(13, 124, 84, 0.28);
 }
 
-.patrol-code-input__option:not([disabled]):hover,
-.patrol-code-input__option:not([disabled]):focus-visible {
-  border-color: #0d7c54;
-  box-shadow: 0 0 0 2px rgba(13, 124, 84, 0.15);
+.patrol-code-input__wheel-option:disabled,
+.points-input__wheel-option:disabled {
+  cursor: not-allowed;
 }
 
-.patrol-code-input input {
-  appearance: none;
-  border: 1px solid rgba(11, 83, 70, 0.25);
-  border-radius: 999px;
-  padding: 10px 16px;
-  font-weight: 600;
-  background: rgba(255, 255, 255, 0.92);
-  color: #0a4236;
-  font-size: 16px;
-  letter-spacing: 0.12em;
+.patrol-code-input__value,
+.points-input__value {
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  width: 100%;
+  color: #0a4236;
 }
 
-.patrol-code-input small {
+.patrol-code-input small,
+.points-input small {
   font-size: 0.75rem;
   color: rgba(11, 83, 70, 0.6);
 }
 
-.patrol-code-input small.invalid {
+.patrol-code-input small.invalid,
+.points-input small.invalid {
   color: #b91c1c;
+}
+
+.points-input__value {
+  letter-spacing: 0.08em;
+}
+
+.points-input__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.points-input__clear {
+  padding: 6px 12px;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .judge-display {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import localforage from 'localforage';
 import LastScoresList from './components/LastScoresList';
 import TargetAnswersReport from './components/TargetAnswersReport';
 import PatrolCodeInput from './components/PatrolCodeInput';
+import PointsInput from './components/PointsInput';
 import OfflineHealth from './components/OfflineHealth';
 import AppFooter from './components/AppFooter';
 import { supabase } from './supabaseClient';
@@ -383,7 +384,7 @@ function StationApp({
   const tempCodesRef = useRef<Map<string, string>>(new Map());
   const tempCounterRef = useRef(1);
   const formRef = useRef<HTMLElement | null>(null);
-  const pointsInputRef = useRef<HTMLInputElement | null>(null);
+  const pointsInputRef = useRef<HTMLButtonElement | null>(null);
   const answersInputRef = useRef<HTMLInputElement | null>(null);
   const [isOnline, setIsOnline] = useState(typeof navigator !== 'undefined' ? navigator.onLine : true);
   const [startTime, setStartTime] = useState<string | null>(null);
@@ -2243,18 +2244,13 @@ function StationApp({
                     {answersError ? <p className="error-text">{answersError}</p> : null}
                   </div>
                 ) : (
-                  <label>
-                    Body (0 až 12)
-                    <input
-                      ref={pointsInputRef}
-                      value={points}
-                      onChange={(event) => setPoints(event.target.value)}
-                      type="number"
-                      inputMode="numeric"
-                      min={0}
-                      max={12}
-                    />
-                  </label>
+                  <PointsInput
+                    ref={pointsInputRef}
+                    value={points}
+                    onChange={setPoints}
+                    label="Body (0 až 12)"
+                    helperText="Vyber počet bodů, které hlídka získala."
+                  />
                 )}
                 <button type="button" className="primary" onClick={handleSave}>
                   Uložit záznam

--- a/web/src/components/PatrolCodeInput.tsx
+++ b/web/src/components/PatrolCodeInput.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useId, useMemo } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef } from 'react';
 
-const PATROL_CODE_REGEX = /^[NMSR][HD]-(?:[1-9]|[1-3][0-9])$/;
+const PATROL_CODE_REGEX = /^[NMSR][HD]-(?:[1-9]|[1-3][0-9]|40)$/;
 
 const CATEGORY_OPTIONS = ['N', 'M', 'S', 'R'] as const;
 const TYPE_OPTIONS = ['H', 'D'] as const;
+const NUMBER_OPTIONS = Array.from({ length: 40 }, (_, index) => String(index + 1)) as const;
 
 type CategoryOption = (typeof CATEGORY_OPTIONS)[number];
 type TypeOption = (typeof TYPE_OPTIONS)[number];
@@ -59,9 +60,10 @@ export function normalisePatrolCode(raw: string) {
 export default function PatrolCodeInput({ value, onChange, id, label }: PatrolCodeInputProps) {
   const generatedId = useId();
   const inputId = id ?? generatedId;
+  const labelId = label ? `${inputId}-label` : undefined;
   const feedbackId = `${inputId}-feedback`;
 
-  const { normalisedValue, selectedCategory, selectedType, digits } = useMemo(() => {
+  const { normalisedValue, selectedCategory, selectedType, selectedNumber } = useMemo(() => {
     const normalised = normalisePatrolCode(value);
     const categoryOption = CATEGORY_OPTIONS.find((option) => normalised.startsWith(option)) ?? '';
     const typeCandidate = normalised.charAt(1);
@@ -70,25 +72,16 @@ export default function PatrolCodeInput({ value, onChange, id, label }: PatrolCo
         ? (typeCandidate as TypeOption)
         : '';
     const digitsMatch = normalised.match(/-(\d{1,2})$/);
+    const parsedNumber = digitsMatch ? Number.parseInt(digitsMatch[1], 10) : NaN;
+    const numberOption = Number.isNaN(parsedNumber) ? '' : String(parsedNumber);
 
     return {
       normalisedValue: normalised,
       selectedCategory: categoryOption,
       selectedType: typeOption,
-      digits: digitsMatch ? digitsMatch[1] : '',
+      selectedNumber: numberOption,
     };
   }, [value]);
-
-  const handleChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const raw = event.target.value;
-      let next = raw.toUpperCase();
-      next = next.replace(/[^A-Z0-9-]/g, '');
-      next = normalisePatrolCode(next);
-      onChange(next);
-    },
-    [onChange],
-  );
 
   const handleCategorySelect = useCallback(
     (option: CategoryOption) => {
@@ -100,14 +93,14 @@ export default function PatrolCodeInput({ value, onChange, id, label }: PatrolCo
 
       if (selectedType) {
         nextValue += selectedType;
-        nextValue += digits ? `-${digits}` : '-';
-      } else if (digits) {
-        nextValue += `-${digits}`;
+        nextValue += selectedNumber ? `-${selectedNumber}` : '-';
+      } else if (selectedNumber) {
+        nextValue += `-${selectedNumber}`;
       }
 
       onChange(nextValue);
     },
-    [digits, onChange, selectedCategory, selectedType],
+    [onChange, selectedCategory, selectedNumber, selectedType],
   );
 
   const handleTypeSelect = useCallback(
@@ -117,70 +110,303 @@ export default function PatrolCodeInput({ value, onChange, id, label }: PatrolCo
       }
 
       let nextValue = `${selectedCategory}${option}`;
-      nextValue += digits ? `-${digits}` : '-';
+      nextValue += selectedNumber ? `-${selectedNumber}` : '-';
 
       onChange(nextValue);
     },
-    [digits, onChange, selectedCategory, selectedType],
+    [onChange, selectedCategory, selectedNumber, selectedType],
+  );
+
+  const handleNumberSelect = useCallback(
+    (option: string) => {
+      if (!selectedCategory || !selectedType) {
+        return;
+      }
+
+      onChange(`${selectedCategory}${selectedType}-${option}`);
+    },
+    [onChange, selectedCategory, selectedType],
   );
 
   const isValid = PATROL_CODE_REGEX.test(normalisedValue.trim().toUpperCase());
-  const shouldUseNumericKeyboard = normalisedValue.includes('-') && normalisedValue.length >= 3;
+
+  const displayValue = normalisedValue || '—';
 
   return (
     <div className="patrol-code-input">
       {label ? (
-        <label className="patrol-code-input__label" htmlFor={inputId}>
+        <span className="patrol-code-input__label" id={labelId}>
           {label}
-        </label>
+        </span>
       ) : null}
-      <div className="patrol-code-input__selectors">
-        <div className="patrol-code-input__options" role="group" aria-label="Kategorie hlídky">
-          {CATEGORY_OPTIONS.map((option) => (
-            <button
-              type="button"
-              key={option}
-              className="patrol-code-input__option"
-              onClick={() => handleCategorySelect(option)}
-              aria-pressed={selectedCategory === option}
-            >
-              {option}
-            </button>
-          ))}
-        </div>
-        <div
-          className="patrol-code-input__options"
-          role="group"
-          aria-label="Družina nebo hlídka"
-          aria-disabled={!selectedCategory}
-        >
-          {TYPE_OPTIONS.map((option) => (
-            <button
-              type="button"
-              key={option}
-              className="patrol-code-input__option"
-              onClick={() => handleTypeSelect(option)}
-              aria-pressed={selectedType === option}
-              disabled={!selectedCategory}
-            >
-              {option}
-            </button>
-          ))}
-        </div>
+      <div
+        className="patrol-code-input__wheel-group"
+        role="group"
+        aria-labelledby={labelId}
+      >
+        <WheelColumn
+          options={CATEGORY_OPTIONS}
+          selected={selectedCategory}
+          onSelect={handleCategorySelect}
+          ariaLabel="Kategorie hlídky"
+        />
+        <WheelColumn
+          options={TYPE_OPTIONS}
+          selected={selectedType}
+          onSelect={handleTypeSelect}
+          ariaLabel="Družina nebo hlídka"
+          disabled={!selectedCategory}
+        />
+        <WheelColumn
+          options={NUMBER_OPTIONS}
+          selected={selectedNumber}
+          onSelect={handleNumberSelect}
+          ariaLabel="Číslo hlídky"
+          disabled={!selectedCategory || !selectedType}
+        />
       </div>
-      <input
-        id={inputId}
-        value={normalisedValue}
-        onChange={handleChange}
-        placeholder="např. NH-15"
-        autoComplete="off"
-        inputMode={shouldUseNumericKeyboard ? 'numeric' : 'text'}
-        pattern="[A-Za-z0-9-]*"
-        aria-describedby={feedbackId}
-      />
+      <div className="patrol-code-input__value" aria-live="polite">
+        {displayValue}
+      </div>
       <small id={feedbackId} className={isValid ? 'valid' : 'invalid'}>
-        {isValid ? 'Kód je platný' : 'Formát: N/M/S/R + H/D + číslo 1–39 (např. NH-5)'}
+        {isValid ? 'Kód je platný' : 'Formát: N/M/S/R + H/D + číslo 1–40 (např. NH-5)'}
       </small>
+    </div>
+  );
+}
+
+interface WheelColumnProps<Option extends string> {
+  options: readonly Option[];
+  selected: Option | '';
+  onSelect: (option: Option) => void;
+  ariaLabel: string;
+  disabled?: boolean;
+}
+
+function WheelColumn<Option extends string>({
+  options,
+  selected,
+  onSelect,
+  ariaLabel,
+  disabled = false,
+}: WheelColumnProps<Option>) {
+  const wheelRef = useRef<HTMLDivElement | null>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const scrollTimeoutRef = useRef<number | null>(null);
+  const programmaticScrollRef = useRef(false);
+  const isInitialRenderRef = useRef(true);
+
+  useEffect(() => {
+    optionRefs.current = optionRefs.current.slice(0, options.length);
+  }, [options.length]);
+
+  const updateWheelPadding = useCallback(() => {
+    const wheel = wheelRef.current;
+    if (!wheel) {
+      return;
+    }
+    const firstOption = optionRefs.current.find((node) => node);
+    if (!firstOption) {
+      return;
+    }
+    const wheelHeight = wheel.clientHeight;
+    if (wheelHeight <= 0) {
+      return;
+    }
+    const optionHeight = firstOption.offsetHeight || 0;
+    const padding = Math.max(0, wheelHeight / 2 - optionHeight / 2);
+    wheel.style.setProperty('--wheel-padding', `${padding}px`);
+  }, []);
+
+  useEffect(() => {
+    updateWheelPadding();
+  }, [options.length, updateWheelPadding]);
+
+  useEffect(() => {
+    const handleResize = () => updateWheelPadding();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [updateWheelPadding]);
+
+  useEffect(() => {
+    return () => {
+      if (scrollTimeoutRef.current !== null) {
+        window.clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const scrollToOption = useCallback((index: number, behavior: ScrollBehavior = 'smooth') => {
+    const wheel = wheelRef.current;
+    const optionNode = optionRefs.current[index];
+    if (!wheel || !optionNode) {
+      return;
+    }
+
+    const wheelHeight = wheel.clientHeight;
+    const optionOffsetTop = optionNode.offsetTop;
+    const optionHeight = optionNode.offsetHeight;
+    const targetScrollTop = optionOffsetTop - wheelHeight / 2 + optionHeight / 2;
+
+    programmaticScrollRef.current = true;
+    if (typeof wheel.scrollTo === 'function') {
+      wheel.scrollTo({ top: targetScrollTop, behavior });
+    } else {
+      wheel.scrollTop = targetScrollTop;
+    }
+    if (behavior === 'auto') {
+      programmaticScrollRef.current = false;
+    }
+  }, []);
+
+  const handleOptionSelect = useCallback(
+    (option: Option) => {
+      if (disabled) {
+        return;
+      }
+      if (option === selected) {
+        const existingIndex = options.indexOf(option);
+        if (existingIndex >= 0) {
+          scrollToOption(existingIndex);
+        }
+        return;
+      }
+
+      onSelect(option);
+      const selectedIndex = options.indexOf(option);
+      if (selectedIndex >= 0) {
+        scrollToOption(selectedIndex);
+      }
+    },
+    [disabled, onSelect, options, scrollToOption, selected],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
+      if (disabled) {
+        return;
+      }
+
+      if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+        event.preventDefault();
+        const nextIndex = currentIndex === 0 ? options.length - 1 : currentIndex - 1;
+        handleOptionSelect(options[nextIndex]);
+      } else if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+        event.preventDefault();
+        const nextIndex = currentIndex === options.length - 1 ? 0 : currentIndex + 1;
+        handleOptionSelect(options[nextIndex]);
+      }
+    },
+    [disabled, handleOptionSelect, options],
+  );
+
+  const handleScroll = useCallback(() => {
+    if (disabled || !wheelRef.current || options.length === 0) {
+      return;
+    }
+
+    if (scrollTimeoutRef.current !== null) {
+      window.clearTimeout(scrollTimeoutRef.current);
+    }
+
+    const programmaticScroll = programmaticScrollRef.current;
+    scrollTimeoutRef.current = window.setTimeout(() => {
+      if (programmaticScroll) {
+        programmaticScrollRef.current = false;
+        return;
+      }
+
+      const wheel = wheelRef.current;
+      if (!wheel) {
+        return;
+      }
+
+      const { top, height } = wheel.getBoundingClientRect();
+      const centerY = top + height / 2;
+      let closestIndex = -1;
+      let shortestDistance = Number.POSITIVE_INFINITY;
+
+      optionRefs.current.forEach((node, index) => {
+        if (!node) {
+          return;
+        }
+        const rect = node.getBoundingClientRect();
+        const optionCenter = rect.top + rect.height / 2;
+        const distance = Math.abs(optionCenter - centerY);
+        if (distance < shortestDistance) {
+          shortestDistance = distance;
+          closestIndex = index;
+        }
+      });
+
+      if (closestIndex >= 0) {
+        const nextOption = options[closestIndex];
+        if (nextOption !== selected) {
+          handleOptionSelect(nextOption);
+        } else {
+          scrollToOption(closestIndex);
+        }
+      }
+    }, 80);
+  }, [disabled, handleOptionSelect, options, scrollToOption, selected]);
+
+  useEffect(() => {
+    if (options.length === 0) {
+      return;
+    }
+    const nextIndex = selected ? options.indexOf(selected) : 0;
+    if (nextIndex < 0) {
+      return;
+    }
+    const behavior = isInitialRenderRef.current ? 'auto' : 'smooth';
+    isInitialRenderRef.current = false;
+    scrollToOption(nextIndex, behavior);
+  }, [options, scrollToOption, selected]);
+
+  const registerOptionRef = useCallback(
+    (index: number) => (node: HTMLButtonElement | null) => {
+      optionRefs.current[index] = node;
+      if (node) {
+        updateWheelPadding();
+      }
+    },
+    [updateWheelPadding],
+  );
+
+  return (
+    <div
+      className="patrol-code-input__wheel"
+      role="radiogroup"
+      aria-label={ariaLabel}
+      aria-disabled={disabled || undefined}
+      ref={wheelRef}
+      onScroll={handleScroll}
+    >
+      {options.map((option, index) => {
+        const isSelected = selected === option;
+        const className = [
+          'patrol-code-input__wheel-option',
+          isSelected ? 'patrol-code-input__wheel-option--selected' : '',
+        ]
+          .filter(Boolean)
+          .join(' ');
+
+        return (
+          <button
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            key={option}
+            className={className}
+            onClick={() => handleOptionSelect(option)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+            disabled={disabled}
+            ref={registerOptionRef(index)}
+          >
+            {option}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/web/src/components/PointsInput.tsx
+++ b/web/src/components/PointsInput.tsx
@@ -1,0 +1,337 @@
+import { forwardRef, useCallback, useEffect, useId, useMemo, useRef } from 'react';
+import type { KeyboardEvent, MutableRefObject } from 'react';
+
+type PointsOption = string;
+
+interface PointsInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  id?: string;
+  label?: string;
+  min?: number;
+  max?: number;
+  helperText?: string;
+  clearLabel?: string;
+}
+
+function normaliseBounds(min: number | undefined, max: number | undefined) {
+  if (typeof min === 'number' && typeof max === 'number') {
+    return min <= max ? [min, max] : [max, min];
+  }
+  if (typeof min === 'number') {
+    return [min, min + 12];
+  }
+  if (typeof max === 'number') {
+    return [Math.max(0, max - 12), max];
+  }
+  return [0, 12];
+}
+
+function resolveSelectedValue(raw: string, min: number, max: number) {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return '';
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    return '';
+  }
+  return String(parsed);
+}
+
+const PointsInput = forwardRef<HTMLButtonElement, PointsInputProps>(function PointsInput(
+  {
+    value,
+    onChange,
+    id,
+    label,
+    min,
+    max,
+    helperText,
+    clearLabel = 'Vymazat výběr',
+  },
+  ref,
+) {
+  const [resolvedMin, resolvedMax] = normaliseBounds(min, max);
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const labelId = label ? `${inputId}-label` : undefined;
+  const helperId = `${inputId}-helper`;
+
+  const options = useMemo(() => {
+    return Array.from(
+      { length: resolvedMax - resolvedMin + 1 },
+      (_, index) => String(resolvedMin + index),
+    ) as readonly PointsOption[];
+  }, [resolvedMax, resolvedMin]);
+
+  const selectedOption = useMemo(
+    () => resolveSelectedValue(value, resolvedMin, resolvedMax),
+    [value, resolvedMin, resolvedMax],
+  );
+
+  const helperMessage = helperText ?? `Vyber body v rozsahu ${resolvedMin} až ${resolvedMax}.`;
+  const isValidSelection = selectedOption !== '';
+  const displayValue = selectedOption ? `${selectedOption} b` : '—';
+
+  const focusIndex = (() => {
+    if (!selectedOption) {
+      return 0;
+    }
+    const matchIndex = options.indexOf(selectedOption);
+    return matchIndex >= 0 ? matchIndex : 0;
+  })();
+
+  const wheelRef = useRef<HTMLDivElement | null>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const scrollTimeoutRef = useRef<number | null>(null);
+  const programmaticScrollRef = useRef(false);
+  const isInitialRenderRef = useRef(true);
+
+  useEffect(() => {
+    optionRefs.current = optionRefs.current.slice(0, options.length);
+  }, [options.length]);
+
+  const setFocusRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        (ref as MutableRefObject<HTMLButtonElement | null>).current = node;
+      }
+    },
+    [ref],
+  );
+
+  const updateWheelPadding = useCallback(() => {
+    const wheel = wheelRef.current;
+    if (!wheel) {
+      return;
+    }
+    const firstOption = optionRefs.current.find((node) => node);
+    if (!firstOption) {
+      return;
+    }
+    const wheelHeight = wheel.clientHeight;
+    if (wheelHeight <= 0) {
+      return;
+    }
+    const optionHeight = firstOption.offsetHeight || 0;
+    const padding = Math.max(0, wheelHeight / 2 - optionHeight / 2);
+    wheel.style.setProperty('--wheel-padding', `${padding}px`);
+  }, []);
+
+  useEffect(() => {
+    updateWheelPadding();
+  }, [options.length, updateWheelPadding]);
+
+  useEffect(() => {
+    const handleResize = () => updateWheelPadding();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [updateWheelPadding]);
+
+  const scrollToOption = useCallback((index: number, behavior: ScrollBehavior = 'smooth') => {
+    const wheel = wheelRef.current;
+    const optionNode = optionRefs.current[index];
+    if (!wheel || !optionNode) {
+      return;
+    }
+
+    const wheelHeight = wheel.clientHeight;
+    const optionOffsetTop = optionNode.offsetTop;
+    const optionHeight = optionNode.offsetHeight;
+    const targetScrollTop = optionOffsetTop - wheelHeight / 2 + optionHeight / 2;
+
+    programmaticScrollRef.current = true;
+    if (typeof wheel.scrollTo === 'function') {
+      wheel.scrollTo({ top: targetScrollTop, behavior });
+    } else {
+      wheel.scrollTop = targetScrollTop;
+    }
+    if (behavior === 'auto') {
+      programmaticScrollRef.current = false;
+    }
+  }, []);
+
+  const handleSelect = useCallback(
+    (option: PointsOption) => {
+      if (option === selectedOption) {
+        const existingIndex = options.indexOf(option);
+        if (existingIndex >= 0) {
+          scrollToOption(existingIndex);
+        }
+        return;
+      }
+      onChange(option);
+      const selectedIndex = options.indexOf(option);
+      if (selectedIndex >= 0) {
+        scrollToOption(selectedIndex);
+      }
+    },
+    [onChange, options, scrollToOption, selectedOption],
+  );
+
+  const handleClear = useCallback(() => {
+    onChange('');
+  }, [onChange]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
+      if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+        event.preventDefault();
+        const nextIndex = currentIndex === 0 ? options.length - 1 : currentIndex - 1;
+        handleSelect(options[nextIndex]);
+      } else if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+        event.preventDefault();
+        const nextIndex = currentIndex === options.length - 1 ? 0 : currentIndex + 1;
+        handleSelect(options[nextIndex]);
+      }
+    },
+    [handleSelect, options],
+  );
+
+  const handleWheelScroll = useCallback(() => {
+    if (!wheelRef.current || options.length === 0) {
+      return;
+    }
+
+    if (scrollTimeoutRef.current !== null) {
+      window.clearTimeout(scrollTimeoutRef.current);
+    }
+
+    const programmaticScroll = programmaticScrollRef.current;
+    scrollTimeoutRef.current = window.setTimeout(() => {
+      if (programmaticScroll) {
+        programmaticScrollRef.current = false;
+        return;
+      }
+
+      const wheel = wheelRef.current;
+      if (!wheel) {
+        return;
+      }
+
+      const { top, height } = wheel.getBoundingClientRect();
+      const centerY = top + height / 2;
+      let closestIndex = -1;
+      let shortestDistance = Number.POSITIVE_INFINITY;
+
+      optionRefs.current.forEach((node, index) => {
+        if (!node) {
+          return;
+        }
+        const rect = node.getBoundingClientRect();
+        const optionCenter = rect.top + rect.height / 2;
+        const distance = Math.abs(optionCenter - centerY);
+        if (distance < shortestDistance) {
+          shortestDistance = distance;
+          closestIndex = index;
+        }
+      });
+
+      if (closestIndex >= 0) {
+        const nextOption = options[closestIndex];
+        if (nextOption !== selectedOption) {
+          handleSelect(nextOption);
+        } else {
+          scrollToOption(closestIndex);
+        }
+      }
+    }, 80);
+  }, [handleSelect, options, scrollToOption, selectedOption]);
+
+  useEffect(() => {
+    if (options.length === 0) {
+      return;
+    }
+    const nextIndex = selectedOption ? options.indexOf(selectedOption) : 0;
+    if (nextIndex < 0) {
+      return;
+    }
+    const behavior = isInitialRenderRef.current ? 'auto' : 'smooth';
+    isInitialRenderRef.current = false;
+    scrollToOption(nextIndex, behavior);
+  }, [options, scrollToOption, selectedOption]);
+
+  useEffect(() => {
+    return () => {
+      if (scrollTimeoutRef.current !== null) {
+        window.clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const registerOptionRef = useCallback(
+    (index: number) => (node: HTMLButtonElement | null) => {
+      optionRefs.current[index] = node;
+      if (index === focusIndex) {
+        setFocusRef(node);
+      }
+      if (node) {
+        updateWheelPadding();
+      }
+    },
+    [focusIndex, setFocusRef, updateWheelPadding],
+  );
+
+  return (
+    <div className="points-input">
+      {label ? (
+        <span className="points-input__label" id={labelId}>
+          {label}
+        </span>
+      ) : null}
+      <div className="points-input__wheel-group">
+        <div
+          className="points-input__wheel"
+          role="radiogroup"
+          aria-labelledby={labelId}
+          aria-describedby={helperId}
+          ref={wheelRef}
+          onScroll={handleWheelScroll}
+        >
+          {options.map((option, index) => {
+            const isSelected = selectedOption === option;
+            const className = [
+              'points-input__wheel-option',
+              isSelected ? 'points-input__wheel-option--selected' : '',
+            ]
+              .filter(Boolean)
+              .join(' ');
+
+            return (
+              <button
+                type="button"
+                role="radio"
+                aria-checked={isSelected}
+                key={option}
+                className={className}
+                onClick={() => handleSelect(option)}
+                onKeyDown={(event) => handleKeyDown(event, index)}
+                ref={registerOptionRef(index)}
+              >
+                {option}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div className="points-input__value" aria-live="polite">
+        {displayValue}
+      </div>
+      <div className="points-input__actions">
+        <small id={helperId} className={isValidSelection ? undefined : 'invalid'}>
+          {helperMessage}
+        </small>
+        {value ? (
+          <button type="button" className="ghost points-input__clear" onClick={handleClear}>
+            {clearLabel}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+});
+
+export default PointsInput;


### PR DESCRIPTION
## Summary
- add scroll-driven selection, programmatic centring, and padding calibration to the manual points picker
- extend the patrol code wheel columns with the same scroll logic so each segment can be rolled into place
- update the shared picker styling to use scroll snapping and touch scrolling for a wheel-like experience

## Testing
- `npm --prefix web run test -- --run --reporter=basic`


------
https://chatgpt.com/codex/tasks/task_e_68ddb7d1dd288326950b223c7c181aa4