### PR TITLE
Constrain patrol code wheel to vertical scrolling

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -321,13 +321,16 @@ body {
   background: rgba(255, 255, 255, 0.92);
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
   overflow-y: auto;
   scrollbar-width: thin;
   scroll-snap-type: y mandatory;
   scroll-padding-block: var(--wheel-padding);
   scroll-behavior: smooth;
   overscroll-behavior-y: contain;
+  overscroll-behavior-x: contain;
   -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
 }
 
 .patrol-code-input__wheel::before,


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling on patrol code wheel columns by hiding overflow and restricting touch gestures
- improve touch experience by limiting overscroll to vertical interactions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de1de198c08326a457fc459b056dff