### PR TITLE
Improve patrol code picker layout and behavior

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -300,7 +300,33 @@ body {
   color: rgba(11, 83, 70, 0.7);
 }
 
-.patrol-code-input__wheel-group,
+.patrol-code-input__wheel-group {
+  position: relative;
+  display: flex;
+  gap: 0;
+  align-items: stretch;
+  padding-inline: 8px;
+  border-radius: 20px;
+  border: 1px solid rgba(11, 83, 70, 0.24);
+  background: rgba(255, 255, 255, 0.92);
+  overflow: hidden;
+}
+
+.patrol-code-input__wheel-group::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 8px;
+  right: 8px;
+  transform: translateY(-50%);
+  height: 38px;
+  border-radius: 14px;
+  background: rgba(13, 124, 84, 0.12);
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(13, 124, 84, 0.1);
+  z-index: 1;
+}
+
 .points-input__wheel-group {
   display: flex;
   gap: 14px;
@@ -311,14 +337,10 @@ body {
 .points-input__wheel {
   position: relative;
   flex: 1 1 0;
-  min-width: 72px;
   max-height: 220px;
   --wheel-padding: 72px;
   padding-block: var(--wheel-padding);
   padding-inline: 0;
-  border-radius: 20px;
-  border: 1px solid rgba(11, 83, 70, 0.24);
-  background: rgba(255, 255, 255, 0.92);
   display: flex;
   flex-direction: column;
   overflow-x: hidden;
@@ -333,7 +355,25 @@ body {
   touch-action: pan-y;
 }
 
-.patrol-code-input__wheel::before,
+.patrol-code-input__wheel {
+  min-width: 60px;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  z-index: 2;
+}
+
+.patrol-code-input__wheel + .patrol-code-input__wheel {
+  border-left: 1px solid rgba(13, 124, 84, 0.12);
+}
+
+.points-input__wheel {
+  min-width: 72px;
+  border-radius: 20px;
+  border: 1px solid rgba(11, 83, 70, 0.24);
+  background: rgba(255, 255, 255, 0.92);
+}
+
 .points-input__wheel::before {
   content: '';
   position: sticky;
@@ -346,6 +386,10 @@ body {
   pointer-events: none;
   box-shadow: inset 0 0 0 1px rgba(13, 124, 84, 0.1);
   z-index: 1;
+}
+
+.patrol-code-input__wheel::before {
+  content: none;
 }
 
 .patrol-code-input__wheel::after,
@@ -389,6 +433,10 @@ body {
   z-index: 3;
   scroll-snap-align: center;
   scroll-snap-stop: always;
+}
+
+.patrol-code-input__wheel-option {
+  margin-inline: 8px;
 }
 
 .patrol-code-input__wheel-option:focus-visible,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import localforage from 'localforage';
 // import QRScanner from './components/QRScanner';
 import LastScoresList from './components/LastScoresList';
 import TargetAnswersReport from './components/TargetAnswersReport';
-import PatrolCodeInput from './components/PatrolCodeInput';
+import PatrolCodeInput, { normalisePatrolCode } from './components/PatrolCodeInput';
 import PointsInput from './components/PointsInput';
 import OfflineHealth from './components/OfflineHealth';
 import AppFooter from './components/AppFooter';
@@ -552,6 +552,22 @@ function StationApp({
       });
     });
     return map;
+  }, [auth.patrols]);
+
+  const availablePatrolCodes = useMemo(() => {
+    const unique = new Set<string>();
+    const codes: string[] = [];
+    auth.patrols.forEach((summary) => {
+      const normalised = normalisePatrolCode(summary.patrol_code ?? '');
+      if (!normalised) {
+        return;
+      }
+      if (!unique.has(normalised)) {
+        unique.add(normalised);
+        codes.push(normalised);
+      }
+    });
+    return codes;
   }, [auth.patrols]);
 
   const loadTimingData = useCallback(
@@ -1943,6 +1959,7 @@ function StationApp({
                   value={manualCode}
                   onChange={setManualCode}
                   label="Ruční kód"
+                  availableCodes={availablePatrolCodes}
                 />
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- combine the manual patrol code columns into a single compact control with a shared highlight bar and slimmer styling
- limit the numeric column to real patrol codes by deriving the available options from the downloaded manifest
- smooth out manual scrolling by adding velocity-aware snap logic that respects inertial gestures

## Testing
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68de2188d3448326925e67575224d128