### PR TITLE
Implement backend-driven patrol picker with validation and haptics

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -374,6 +374,7 @@ body {
   flex-direction: column;
   gap: 12px;
   flex: 1 1 220px;
+  --wheel-row-height: 48px;
 }
 
 .patrol-code-input__label,
@@ -405,7 +406,7 @@ body {
   left: 12px;
   right: 12px;
   transform: translateY(-50%);
-  height: 38px;
+  height: var(--wheel-row-height);
   border-radius: 14px;
   background: rgba(13, 124, 84, 0.12);
   pointer-events: none;
@@ -423,8 +424,8 @@ body {
 .points-input__wheel {
   position: relative;
   flex: 1 1 0;
-  max-height: 220px;
-  --wheel-padding: 72px;
+  max-height: calc(var(--wheel-row-height) * 5);
+  --wheel-padding: calc(var(--wheel-row-height) * 2);
   padding-block: var(--wheel-padding);
   padding-inline: 0;
   display: flex;
@@ -510,8 +511,8 @@ body {
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  padding: 8px 0;
-  margin: 4px 0;
+  padding: 0;
+  margin: 6px 0;
   border-radius: 14px;
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
@@ -523,7 +524,8 @@ body {
   align-items: center;
   justify-content: center;
   width: 100%;
-  line-height: 1.1;
+  line-height: 1;
+  min-height: var(--wheel-row-height);
 }
 
 .patrol-code-input__wheel-option {
@@ -556,6 +558,12 @@ body {
 .patrol-code-input__wheel-option:disabled,
 .points-input__wheel-option:disabled {
   cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.patrol-code-input__wheel-option[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 .patrol-code-input__value,
@@ -573,9 +581,52 @@ body {
   color: rgba(11, 83, 70, 0.6);
 }
 
+.patrol-code-input small.valid {
+  color: #047857;
+}
+
 .patrol-code-input small.invalid,
 .points-input small.invalid {
   color: #b91c1c;
+}
+
+.patrol-code-input__fallback {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.patrol-code-input__fallback label {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(11, 83, 70, 0.6);
+}
+
+.patrol-code-input__fallback input {
+  border: 1px solid rgba(11, 83, 70, 0.24);
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #0a4236;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.patrol-code-input__fallback input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(13, 124, 84, 0.35);
+}
+
+.patrol-code-input__error {
+  font-size: 0.75rem;
+  color: #b91c1c;
+}
+
+.patrol-code-input__actions {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .points-input__value {

--- a/web/src/components/PatrolCodeInput.tsx
+++ b/web/src/components/PatrolCodeInput.tsx
@@ -1,229 +1,656 @@
-import { useCallback, useEffect, useId, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
 
-const PATROL_CODE_REGEX = /^[NMSR][HD]-(?:[1-9]|[1-3][0-9]|40)$/;
+import { supabase } from '../supabaseClient';
 
 const CATEGORY_OPTIONS = ['N', 'M', 'S', 'R'] as const;
-const TYPE_OPTIONS = ['H', 'D'] as const;
-const NUMBER_OPTIONS = Array.from({ length: 40 }, (_, index) => String(index + 1)) as const;
+const GENDER_OPTIONS = ['H', 'D'] as const;
+const HINT_BY_GENDER: Record<GenderOption, string> = {
+  H: 'Hoši',
+  D: 'Dívky',
+};
+const VISIBLE_ROWS = 5;
 
-type CategoryOption = (typeof CATEGORY_OPTIONS)[number];
-type TypeOption = (typeof TYPE_OPTIONS)[number];
+export type CategoryOption = (typeof CATEGORY_OPTIONS)[number];
+export type GenderOption = (typeof GENDER_OPTIONS)[number];
+
+interface WheelOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  title?: string;
+}
+
+interface DirectoryEntry {
+  id: string;
+  category: CategoryOption;
+  gender: GenderOption;
+  number: string; // always padded to two digits
+  code: string; // canonical format (e.g., NH-7)
+  active: boolean;
+}
 
 interface PatrolCodeInputProps {
-  value: string;
-  onChange: (value: string) => void;
+  eventId: string;
+  allowedCategories: ReadonlySet<string>;
+  onConfirm: (payload: { code: string; patrolId: string }) => Promise<void> | void;
+  onChange?: (code: string) => void;
   id?: string;
   label?: string;
-  availableCodes?: readonly string[];
+  disabled?: boolean;
+}
+
+type PatrolDirectory = Map<string, DirectoryEntry[]>; // key: `${category}-${gender}`
+
+type PatrolRow = {
+  id: string;
+  category: CategoryOption;
+  sex: GenderOption;
+  patrol_code: string;
+  active: boolean | null;
+};
+
+function isCategoryOption(value: string): value is CategoryOption {
+  return CATEGORY_OPTIONS.includes(value as CategoryOption);
+}
+
+function isGenderOption(value: string): value is GenderOption {
+  return GENDER_OPTIONS.includes(value as GenderOption);
+}
+
+function padNumber(value: string | number): string {
+  const numeric = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return '';
+  }
+  return String(numeric).padStart(2, '0');
+}
+
+function parseManualParts(raw: string) {
+  const trimmed = raw.trim().toUpperCase();
+  if (!trimmed) {
+    return null;
+  }
+  const cleaned = trimmed.replace(/[^A-Z0-9-]/g, '');
+  const match = cleaned.match(/^([NMSR])[-\s]?([HD])[-\s]?(\d{1,2})$/);
+  if (!match) {
+    return null;
+  }
+  const [, cat, gen, digits] = match;
+  if (!isCategoryOption(cat) || !isGenderOption(gen)) {
+    return null;
+  }
+  const number = padNumber(digits);
+  if (!number) {
+    return null;
+  }
+  return { category: cat, gender: gen, number } as const;
+}
+
+function buildCanonicalCode(category: CategoryOption, gender: GenderOption, paddedNumber: string) {
+  const numeric = Number.parseInt(paddedNumber, 10);
+  if (!Number.isFinite(numeric)) {
+    return '';
+  }
+  return `${category}${gender}-${numeric}`;
+}
+
+function formatDisplayCode(category: string, gender: string, paddedNumber: string) {
+  if (!category || !gender || !paddedNumber) {
+    return '—';
+  }
+  return `${category}-${gender}-${paddedNumber}`;
+}
+
+function getNavigator(): (Navigator & { vibrate?: (pattern: number | number[]) => boolean }) | null {
+  if (typeof navigator === 'undefined') {
+    return null;
+  }
+  return navigator as Navigator & { vibrate?: (pattern: number | number[]) => boolean };
+}
+
+function triggerSelectionHaptic() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const globalAny = window as typeof window & {
+    Capacitor?: { isNativePlatform?: () => boolean; Plugins?: { Haptics?: { selectionChanged?: () => void; selection?: () => void } } };
+    TapticEngine?: { selection: () => void };
+  };
+  const { Capacitor, TapticEngine } = globalAny;
+  const navigatorWithVibrate = getNavigator();
+  if (Capacitor?.isNativePlatform?.()) {
+    const selection = Capacitor.Plugins?.Haptics?.selectionChanged || Capacitor.Plugins?.Haptics?.selection;
+    if (selection) {
+      selection();
+      return;
+    }
+  }
+  if (TapticEngine?.selection) {
+    TapticEngine.selection();
+    return;
+  }
+  const ua = navigatorWithVibrate?.userAgent ?? '';
+  if (/android/i.test(ua) && typeof navigatorWithVibrate?.vibrate === 'function') {
+    navigatorWithVibrate.vibrate(15);
+  }
+}
+
+function triggerConfirmHaptic() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const globalAny = window as typeof window & {
+    Capacitor?: {
+      isNativePlatform?: () => boolean;
+      Plugins?: { Haptics?: { impact?: (options: { style: 'medium' | 'heavy' }) => void; impactOccurred?: () => void } };
+    };
+    TapticEngine?: { impact?: ({ style }: { style: 'medium' | 'heavy' }) => void; notification?: ({ type }: { type: 'success' | 'warning' | 'error' }) => void };
+  };
+  const { Capacitor, TapticEngine } = globalAny;
+  const navigatorWithVibrate = getNavigator();
+  if (Capacitor?.isNativePlatform?.()) {
+    const haptics = Capacitor.Plugins?.Haptics;
+    if (haptics?.impact) {
+      haptics.impact({ style: 'medium' });
+      return;
+    }
+    if (haptics?.impactOccurred) {
+      haptics.impactOccurred();
+      return;
+    }
+  }
+  if (TapticEngine?.impact) {
+    TapticEngine.impact({ style: 'heavy' });
+    return;
+  }
+  if (TapticEngine?.notification) {
+    TapticEngine.notification({ type: 'success' });
+    return;
+  }
+  const ua = navigatorWithVibrate?.userAgent ?? '';
+  if (/android/i.test(ua) && typeof navigatorWithVibrate?.vibrate === 'function') {
+    navigatorWithVibrate.vibrate([20, 30]);
+  }
+}
+
+function logEvent(type: string, payload: Record<string, unknown>) {
+  try {
+    console.info(`[patrol-picker] ${type}`, payload);
+  } catch (error) {
+    // no-op if console unavailable
+  }
 }
 
 export function normalisePatrolCode(raw: string) {
-  const trimmed = raw.trim().toUpperCase();
-  if (!trimmed) return '';
-
-  const cleaned = trimmed.replace(/[^A-Z0-9-]/g, '');
-  const match = cleaned.match(/^([NMSR])(.*)$/);
-  if (!match) {
-    return cleaned;
+  const parts = parseManualParts(raw);
+  if (!parts) {
+    return raw.trim().toUpperCase().replace(/\s+/g, '');
   }
-
-  const [, category, remainder] = match;
-  const trailingHyphen = /-$/.test(cleaned);
-  const compact = remainder.replace(/-/g, '');
-
-  if (!compact) {
-    return category;
-  }
-
-  const letterMatchIndex = compact.search(/[HD]/);
-  const hasLetter = letterMatchIndex === 0;
-  const letter = hasLetter ? compact[0] : '';
-  const digits = compact
-    .slice(hasLetter ? 1 : 0)
-    .replace(/[^0-9]/g, '')
-    .slice(0, 2);
-
-  let result = category;
-
-  if (letter) {
-    result += letter;
-  }
-
-  if (digits) {
-    result += `-${digits}`;
-  } else if (letter || (trailingHyphen && category)) {
-    result += '-';
-  }
-
-  return result;
+  return buildCanonicalCode(parts.category, parts.gender, parts.number);
 }
 
 export default function PatrolCodeInput({
-  value,
+  eventId,
+  allowedCategories,
+  onConfirm,
   onChange,
   id,
   label,
-  availableCodes,
+  disabled = false,
 }: PatrolCodeInputProps) {
   const generatedId = useId();
   const inputId = id ?? generatedId;
   const labelId = label ? `${inputId}-label` : undefined;
   const feedbackId = `${inputId}-feedback`;
+  const fallbackId = `${inputId}-fallback`;
+  const [directory, setDirectory] = useState<PatrolDirectory>(new Map());
+  const [lookupByCode, setLookupByCode] = useState<Map<string, DirectoryEntry>>(new Map());
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [category, setCategory] = useState<CategoryOption | ''>('');
+  const [gender, setGender] = useState<GenderOption | ''>('');
+  const [number, setNumber] = useState<string>('');
+  const [manualInput, setManualInput] = useState('');
+  const [manualError, setManualError] = useState<string | null>(null);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const selectionRef = useRef<{ category: string; gender: string; number: string }>({
+    category: '',
+    gender: '',
+    number: '',
+  });
 
-  const { normalisedValue, selectedCategory, selectedType, selectedNumber } = useMemo(() => {
-    const normalised = normalisePatrolCode(value);
-    const categoryOption = CATEGORY_OPTIONS.find((option) => normalised.startsWith(option)) ?? '';
-    const typeCandidate = normalised.charAt(1);
-    const typeOption =
-      categoryOption && TYPE_OPTIONS.includes(typeCandidate as TypeOption)
-        ? (typeCandidate as TypeOption)
-        : '';
-    const digitsMatch = normalised.match(/-(\d{1,2})$/);
-    const parsedNumber = digitsMatch ? Number.parseInt(digitsMatch[1], 10) : NaN;
-    const numberOption = Number.isNaN(parsedNumber) ? '' : String(parsedNumber);
+  const allowedCategoryOptions = useMemo(() => {
+    if (allowedCategories.size === 0) {
+      return new Set<CategoryOption>(CATEGORY_OPTIONS);
+    }
+    const set = new Set<CategoryOption>();
+    CATEGORY_OPTIONS.forEach((option) => {
+      if (allowedCategories.has(option)) {
+        set.add(option);
+      }
+    });
+    return set.size > 0 ? set : new Set<CategoryOption>(CATEGORY_OPTIONS);
+  }, [allowedCategories]);
 
-    return {
-      normalisedValue: normalised,
-      selectedCategory: categoryOption,
-      selectedType: typeOption,
-      selectedNumber: numberOption,
+  useEffect(() => {
+    let isMounted = true;
+    setIsLoading(true);
+    setLoadError(null);
+    const fetchDirectory = async () => {
+      const { data, error } = await supabase
+        .from('patrols')
+        .select('id, patrol_code, category, sex, active')
+        .eq('event_id', eventId);
+      if (!isMounted) {
+        return;
+      }
+      if (error) {
+        console.error('Failed to load patrol directory', error);
+        setLoadError('Nepodařilo se načíst seznam hlídek.');
+        setDirectory(new Map());
+        setLookupByCode(new Map());
+        setIsLoading(false);
+        logEvent('load-error', { message: error.message, hint: error.hint });
+        return;
+      }
+      const rows = Array.isArray(data) ? (data as PatrolRow[]) : [];
+      const map: PatrolDirectory = new Map();
+      const byCode = new Map<string, DirectoryEntry>();
+      rows.forEach((row) => {
+        if (!row || !row.patrol_code) {
+          return;
+        }
+        let parts = parseManualParts(row.patrol_code);
+        if (!parts) {
+          const canonical = normalisePatrolCode(row.patrol_code);
+          const fallbackParts = parseManualParts(canonical);
+          if (!fallbackParts) {
+            return;
+          }
+          parts = fallbackParts;
+        }
+        let { category: rowCategory, gender: rowGender, number: rowNumber } = parts;
+        if (!isCategoryOption(rowCategory) || !isGenderOption(rowGender)) {
+          return;
+        }
+        const isActive = row.active !== false;
+        const entry: DirectoryEntry = {
+          id: row.id,
+          category: rowCategory,
+          gender: rowGender,
+          number: rowNumber,
+          code: buildCanonicalCode(rowCategory, rowGender, rowNumber),
+          active: isActive,
+        };
+        const key = `${rowCategory}-${rowGender}`;
+        const bucket = map.get(key) ?? [];
+        bucket.push(entry);
+        map.set(key, bucket);
+        byCode.set(entry.code, entry);
+      });
+      map.forEach((bucket) => {
+        bucket.sort((a, b) => Number.parseInt(a.number, 10) - Number.parseInt(b.number, 10));
+      });
+      setDirectory(map);
+      setLookupByCode(byCode);
+      setIsLoading(false);
+      const totals = Array.from(map.values()).flat().reduce(
+        (acc, entry) => {
+          acc.total += 1;
+          if (!entry.active) {
+            acc.unavailable += 1;
+          }
+          return acc;
+        },
+        { total: 0, unavailable: 0 },
+      );
+      if (totals.total > 0) {
+        logEvent('availability', {
+          total: totals.total,
+          unavailable: totals.unavailable,
+          unavailableRatio: totals.unavailable / totals.total,
+        });
+      }
     };
-  }, [value]);
+    void fetchDirectory();
+    return () => {
+      isMounted = false;
+    };
+  }, [eventId]);
 
-  const availableNumbersByGroup = useMemo(() => {
-    if (!availableCodes || availableCodes.length === 0) {
-      return null;
-    }
-
-    const groups = new Map<string, string[]>();
-
-    availableCodes.forEach((raw) => {
-      if (!raw) {
-        return;
-      }
-      const normalised = normalisePatrolCode(raw);
-      const match = normalised.match(/^([NMSR])([HD])-(\d{1,2})$/);
-      if (!match) {
-        return;
-      }
-      const [, category, type, digits] = match;
-      const parsedNumber = Number.parseInt(digits, 10);
-      if (!Number.isFinite(parsedNumber)) {
-        return;
-      }
-      const key = `${category}${type}`;
-      const bucket = groups.get(key) ?? [];
-      const normalizedNumber = String(parsedNumber);
-      if (!bucket.includes(normalizedNumber)) {
-        bucket.push(normalizedNumber);
-      }
-      groups.set(key, bucket);
-    });
-
-    groups.forEach((numbers, key) => {
-      const sorted = numbers
-        .slice()
-        .sort((a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10));
-      groups.set(key, sorted);
-    });
-
-    return groups;
-  }, [availableCodes]);
-
-  const numberOptions = useMemo(() => {
-    if (!availableNumbersByGroup || availableNumbersByGroup.size === 0) {
-      return NUMBER_OPTIONS;
-    }
-
-    if (selectedCategory && selectedType) {
-      const key = `${selectedCategory}${selectedType}`;
-      const scoped = availableNumbersByGroup.get(key);
-      if (scoped && scoped.length > 0) {
-        return scoped as readonly string[];
-      }
-      return selectedNumber ? ([selectedNumber] as readonly string[]) : ([] as readonly string[]);
-    }
-
-    if (selectedCategory) {
-      const aggregated = new Set<string>();
-      availableNumbersByGroup.forEach((numbers, key) => {
-        if (key.startsWith(selectedCategory)) {
-          numbers.forEach((n) => aggregated.add(n));
+  const categoryHasActive = useCallback(
+    (candidate: CategoryOption) => {
+      let hasActive = false;
+      GENDER_OPTIONS.forEach((genderOption) => {
+        const bucket = directory.get(`${candidate}-${genderOption}`);
+        if (bucket && bucket.some((entry) => entry.active)) {
+          hasActive = true;
         }
       });
-      if (aggregated.size > 0) {
-        return Array.from(aggregated).sort(
-          (a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10),
-        ) as readonly string[];
-      }
-      return selectedNumber ? ([selectedNumber] as readonly string[]) : ([] as readonly string[]);
-    }
-
-    return NUMBER_OPTIONS;
-  }, [availableNumbersByGroup, selectedCategory, selectedNumber, selectedType]);
-
-  const handleCategorySelect = useCallback(
-    (option: CategoryOption) => {
-      if (option === selectedCategory) {
-        return;
-      }
-
-      let nextValue = option;
-
-      if (selectedType) {
-        nextValue += selectedType;
-        const scopedNumbers = availableNumbersByGroup?.get(`${option}${selectedType}`);
-        const nextNumber =
-          selectedNumber && scopedNumbers && scopedNumbers.includes(selectedNumber)
-            ? selectedNumber
-            : scopedNumbers && scopedNumbers.length > 0
-              ? scopedNumbers[0]
-              : selectedNumber;
-        nextValue += nextNumber ? `-${nextNumber}` : '-';
-      } else if (selectedNumber) {
-        nextValue += `-${selectedNumber}`;
-      }
-
-      onChange(nextValue);
+      return hasActive;
     },
-    [availableNumbersByGroup, onChange, selectedCategory, selectedNumber, selectedType],
+    [directory],
   );
 
-  const handleTypeSelect = useCallback(
-    (option: TypeOption) => {
-      if (!selectedCategory || option === selectedType) {
+  const findFirstAvailableCategory = useCallback(() => {
+    for (const option of CATEGORY_OPTIONS) {
+      if (!allowedCategoryOptions.has(option)) {
+        continue;
+      }
+      if (categoryHasActive(option)) {
+        return option;
+      }
+    }
+    return '';
+  }, [allowedCategoryOptions, categoryHasActive]);
+
+  const findFirstAvailableGender = useCallback(
+    (candidateCategory: CategoryOption | '') => {
+      if (!candidateCategory) {
+        return '';
+      }
+      for (const genderOption of GENDER_OPTIONS) {
+        const bucket = directory.get(`${candidateCategory}-${genderOption}`) ?? [];
+        if (bucket.some((entry) => entry.active)) {
+          return genderOption;
+        }
+      }
+      return '';
+    },
+    [directory],
+  );
+
+  const pickNextNumber = useCallback(
+    (candidateCategory: CategoryOption | '', candidateGender: GenderOption | '', current: string) => {
+      if (!candidateCategory || !candidateGender) {
+        return '';
+      }
+      const bucket = directory.get(`${candidateCategory}-${candidateGender}`) ?? [];
+      if (bucket.length === 0) {
+        return '';
+      }
+      if (current) {
+        const match = bucket.find((entry) => entry.number === current && entry.active);
+        if (match) {
+          return match.number;
+        }
+      }
+      const activeEntry = bucket.find((entry) => entry.active);
+      if (activeEntry) {
+        return activeEntry.number;
+      }
+      return bucket[0]?.number ?? '';
+    },
+    [directory],
+  );
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    setCategory((previous) => {
+      if (previous && allowedCategoryOptions.has(previous) && categoryHasActive(previous)) {
+        return previous;
+      }
+      const replacement = findFirstAvailableCategory();
+      return replacement || '';
+    });
+  }, [allowedCategoryOptions, categoryHasActive, findFirstAvailableCategory, isLoading]);
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    setGender((previous) => {
+      if (category && previous) {
+        const bucket = directory.get(`${category}-${previous}`) ?? [];
+        if (bucket.some((entry) => entry.active)) {
+          return previous;
+        }
+      }
+      if (!category) {
+        return '';
+      }
+      const fallbackGender = findFirstAvailableGender(category);
+      return fallbackGender || '';
+    });
+  }, [category, directory, findFirstAvailableGender, isLoading]);
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    setNumber((previous) => pickNextNumber(category, gender, previous));
+  }, [category, gender, isLoading, pickNextNumber]);
+
+  useEffect(() => {
+    const current = selectionRef.current;
+    if (current.category !== category || current.gender !== gender || current.number !== number) {
+      selectionRef.current = { category: category ?? '', gender: gender ?? '', number };
+      if (category && gender && number) {
+        logEvent('selection-change', { category, gender, number });
+      }
+    }
+  }, [category, gender, number]);
+
+  const allNumbers = useMemo(() => {
+    const set = new Set<string>();
+    directory.forEach((bucket) => {
+      bucket.forEach((entry) => set.add(entry.number));
+    });
+    const list = Array.from(set);
+    list.sort((a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10));
+    return list;
+  }, [directory]);
+
+  const categoryOptions: WheelOption[] = useMemo(
+    () =>
+      CATEGORY_OPTIONS.map((option) => {
+        const disabledOption =
+          disabled ||
+          !allowedCategoryOptions.has(option) ||
+          !categoryHasActive(option);
+        return { value: option, label: option, disabled: disabledOption };
+      }),
+    [allowedCategoryOptions, categoryHasActive, disabled],
+  );
+
+  const genderOptions: WheelOption[] = useMemo(() => {
+    return GENDER_OPTIONS.map((option) => {
+      if (!category) {
+        return { value: option, label: option, title: HINT_BY_GENDER[option], disabled: true };
+      }
+      const bucket = directory.get(`${category}-${option}`) ?? [];
+      const hasActive = bucket.some((entry) => entry.active);
+      return {
+        value: option,
+        label: option,
+        title: HINT_BY_GENDER[option],
+        disabled: disabled || !hasActive,
+      };
+    });
+  }, [category, directory, disabled]);
+
+  const numberOptions: WheelOption[] = useMemo(() => {
+    if (category && gender) {
+      const bucket = directory.get(`${category}-${gender}`) ?? [];
+      if (bucket.length === 0) {
+        return allNumbers.map((value) => ({ value, label: value, disabled: true }));
+      }
+      return bucket.map((entry) => ({ value: entry.number, label: entry.number, disabled: disabled || !entry.active }));
+    }
+    if (allNumbers.length === 0) {
+      return Array.from({ length: VISIBLE_ROWS }, (_, index) => ({
+        value: `placeholder-${index}`,
+        label: '—',
+        disabled: true,
+      }));
+    }
+    return allNumbers.map((value) => ({ value, label: value, disabled: true }));
+  }, [allNumbers, category, directory, disabled, gender]);
+
+  const selectedEntry = useMemo(() => {
+    if (!category || !gender || !number) {
+      return null;
+    }
+    const bucket = directory.get(`${category}-${gender}`) ?? [];
+    return bucket.find((entry) => entry.number === number) ?? null;
+  }, [category, directory, gender, number]);
+
+  const canonicalCode = useMemo(() => {
+    if (!category || !gender || !number) {
+      return '';
+    }
+    return buildCanonicalCode(category, gender, number);
+  }, [category, gender, number]);
+
+  useEffect(() => {
+    if (!onChange) {
+      return;
+    }
+    if (selectedEntry && selectedEntry.active) {
+      onChange(selectedEntry.code);
+    } else {
+      onChange('');
+    }
+  }, [onChange, selectedEntry]);
+
+  const [isValid, validationMessage] = useMemo(() => {
+    if (isLoading) {
+      return [false, 'Načítám seznam hlídek…'] as const;
+    }
+    if (loadError) {
+      return [false, loadError] as const;
+    }
+    if (!category || !gender || !number) {
+      return [false, 'Vyber kategorii, pohlaví a číslo hlídky.'] as const;
+    }
+    if (!selectedEntry) {
+      return [false, 'Tato kombinace neexistuje. Zvol jiné číslo hlídky.'] as const;
+    }
+    if (!selectedEntry.active) {
+      return [false, 'Tato kombinace je již obsazená. Vyber jiné číslo.'] as const;
+    }
+    return [true, 'Kód je platný'] as const;
+  }, [category, gender, isLoading, loadError, number, selectedEntry]);
+
+  useEffect(() => {
+    logEvent('validation', { code: canonicalCode || null, valid: isValid });
+  }, [canonicalCode, isValid]);
+
+  useEffect(() => {
+    if (category && gender && number) {
+      setManualInput(formatDisplayCode(category, gender, number));
+    } else if (!category && !gender && !number) {
+      setManualInput('');
+    }
+  }, [category, gender, number]);
+
+  const handleCategorySelect = useCallback(
+    (value: string) => {
+      if (disabled) {
         return;
       }
-
-      let nextValue = `${selectedCategory}${option}`;
-      const scopedNumbers = availableNumbersByGroup?.get(`${selectedCategory}${option}`);
-      const nextNumber =
-        selectedNumber && scopedNumbers && scopedNumbers.includes(selectedNumber)
-          ? selectedNumber
-          : scopedNumbers && scopedNumbers.length > 0
-            ? scopedNumbers[0]
-            : selectedNumber;
-      nextValue += nextNumber ? `-${nextNumber}` : '-';
-
-      onChange(nextValue);
+      if (!isCategoryOption(value)) {
+        return;
+      }
+      setCategory(value);
+      setManualError(null);
     },
-    [availableNumbersByGroup, onChange, selectedCategory, selectedNumber, selectedType],
+    [disabled],
+  );
+
+  const handleGenderSelect = useCallback(
+    (value: string) => {
+      if (disabled || !category) {
+        return;
+      }
+      if (!isGenderOption(value)) {
+        return;
+      }
+      setGender(value);
+      setManualError(null);
+    },
+    [category, disabled],
   );
 
   const handleNumberSelect = useCallback(
-    (option: string) => {
-      if (!selectedCategory || !selectedType) {
+    (value: string) => {
+      if (disabled || !category || !gender) {
         return;
       }
-
-      onChange(`${selectedCategory}${selectedType}-${option}`);
+      setNumber(value);
+      setManualError(null);
     },
-    [onChange, selectedCategory, selectedType],
+    [category, disabled, gender],
   );
 
-  const isValid = PATROL_CODE_REGEX.test(normalisedValue.trim().toUpperCase());
+  const applyManualInput = useCallback(() => {
+    if (isLoading) {
+      setManualError('Načítám seznam hlídek…');
+      logEvent('manual-invalid', { reason: 'loading' });
+      return;
+    }
+    if (!manualInput) {
+      setManualError('Zadej kód ve tvaru N-H-07.');
+      logEvent('manual-invalid', { reason: 'empty' });
+      return;
+    }
+    const parts = parseManualParts(manualInput);
+    if (!parts) {
+      setManualError('Neplatný formát. Použij tvar N-H-07.');
+      logEvent('manual-invalid', { reason: 'format', value: manualInput });
+      return;
+    }
+    if (!allowedCategoryOptions.has(parts.category)) {
+      setManualError('Tato kombinace neexistuje. Zvol jiné číslo hlídky.');
+      logEvent('manual-invalid', { reason: 'category-disallowed', value: manualInput });
+      return;
+    }
+    const bucket = directory.get(`${parts.category}-${parts.gender}`) ?? [];
+    const entry = bucket.find((item) => item.number === parts.number);
+    if (!entry || !entry.active) {
+      setManualError('Tato kombinace neexistuje. Zvol jiné číslo hlídky.');
+      logEvent('manual-invalid', { reason: 'combination-missing', value: manualInput });
+      return;
+    }
+    setCategory(parts.category);
+    setGender(parts.gender);
+    setNumber(entry.number);
+    setManualError(null);
+    triggerSelectionHaptic();
+    logEvent('manual-selection', { category: parts.category, gender: parts.gender, number: entry.number });
+  }, [allowedCategoryOptions, directory, isLoading, manualInput]);
 
-  const displayValue = normalisedValue || '—';
+  const handleManualKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        applyManualInput();
+      }
+    },
+    [applyManualInput],
+  );
+
+  const confirmDisabled = disabled || isLoading || isConfirming || !isValid || !selectedEntry;
+
+  const handleConfirm = useCallback(async () => {
+    if (confirmDisabled || !selectedEntry) {
+      return;
+    }
+    setIsConfirming(true);
+    try {
+      triggerConfirmHaptic();
+      logEvent('confirm', { code: selectedEntry.code, patrolId: selectedEntry.id });
+      await onConfirm({ code: selectedEntry.code, patrolId: selectedEntry.id });
+    } finally {
+      setIsConfirming(false);
+    }
+  }, [confirmDisabled, onConfirm, selectedEntry]);
+
+  const statusClassName = isValid ? 'valid' : 'invalid';
+  const displayValue = formatDisplayCode(category, gender, number);
 
   return (
     <div className="patrol-code-input">
@@ -232,67 +659,96 @@ export default function PatrolCodeInput({
           {label}
         </span>
       ) : null}
-      <div
-        className="patrol-code-input__wheel-group"
-        role="group"
-        aria-labelledby={labelId}
-      >
+      <div className="patrol-code-input__wheel-group" role="group" aria-labelledby={labelId}>
         <WheelColumn
-          options={CATEGORY_OPTIONS}
-          selected={selectedCategory}
+          options={categoryOptions}
+          selected={category}
           onSelect={handleCategorySelect}
-          ariaLabel="Kategorie hlídky"
+          ariaLabel="Kategorie"
+          disabled={disabled}
+          onSnap={triggerSelectionHaptic}
         />
         <WheelColumn
-          options={TYPE_OPTIONS}
-          selected={selectedType}
-          onSelect={handleTypeSelect}
-          ariaLabel="Družina nebo hlídka"
-          disabled={!selectedCategory}
+          options={genderOptions}
+          selected={gender}
+          onSelect={handleGenderSelect}
+          ariaLabel="Pohlaví"
+          disabled={disabled || !category}
+          onSnap={triggerSelectionHaptic}
         />
         <WheelColumn
           options={numberOptions}
-          selected={selectedNumber}
+          selected={number}
           onSelect={handleNumberSelect}
           ariaLabel="Číslo hlídky"
-          disabled={!selectedCategory || !selectedType}
+          disabled={disabled || !category || !gender}
+          onSnap={triggerSelectionHaptic}
         />
       </div>
       <div className="patrol-code-input__value" aria-live="polite">
         {displayValue}
       </div>
-      <small id={feedbackId} className={isValid ? 'valid' : 'invalid'}>
-        {isValid ? 'Kód je platný' : 'Formát: N/M/S/R + H/D + číslo 1–40 (např. NH-5)'}
+      <small id={feedbackId} className={statusClassName} role="status" aria-live="polite">
+        {validationMessage}
       </small>
+      <div className="patrol-code-input__fallback">
+        <label htmlFor={fallbackId}>Textové zadání (např. N-H-07)</label>
+        <input
+          id={fallbackId}
+          type="text"
+          inputMode="text"
+          autoCapitalize="characters"
+          autoComplete="off"
+          spellCheck="false"
+          value={manualInput}
+          onChange={(event) => {
+            setManualInput(event.target.value);
+            setManualError(null);
+          }}
+          onBlur={() => {
+            if (manualInput) {
+              applyManualInput();
+            }
+          }}
+          onKeyDown={handleManualKeyDown}
+          aria-describedby={manualError ? `${fallbackId}-error` : undefined}
+        />
+        {manualError ? (
+          <span id={`${fallbackId}-error`} className="patrol-code-input__error" role="alert">
+            {manualError}
+          </span>
+        ) : null}
+      </div>
+      <div className="patrol-code-input__actions">
+        <button
+          type="button"
+          className="primary"
+          onClick={handleConfirm}
+          disabled={confirmDisabled}
+          aria-describedby={feedbackId}
+        >
+          Načíst hlídku
+        </button>
+      </div>
     </div>
   );
 }
 
-interface WheelColumnProps<Option extends string> {
-  options: readonly Option[];
-  selected: Option | '';
-  onSelect: (option: Option) => void;
+interface WheelColumnProps {
+  options: readonly WheelOption[];
+  selected: string;
+  onSelect: (option: string) => void;
   ariaLabel: string;
   disabled?: boolean;
+  onSnap?: () => void;
 }
 
-function WheelColumn<Option extends string>({
-  options,
-  selected,
-  onSelect,
-  ariaLabel,
-  disabled = false,
-}: WheelColumnProps<Option>) {
+function WheelColumn({ options, selected, onSelect, ariaLabel, disabled = false, onSnap }: WheelColumnProps) {
   const wheelRef = useRef<HTMLDivElement | null>(null);
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const scrollTimeoutRef = useRef<number | null>(null);
   const programmaticScrollRef = useRef(false);
   const isInitialRenderRef = useRef(true);
-  const lastScrollInfoRef = useRef<{ top: number; timestamp: number; velocity: number }>({
-    top: 0,
-    timestamp: 0,
-    velocity: 0,
-  });
 
   useEffect(() => {
     optionRefs.current = optionRefs.current.slice(0, options.length);
@@ -307,12 +763,11 @@ function WheelColumn<Option extends string>({
     if (!firstOption) {
       return;
     }
-    const wheelHeight = wheel.clientHeight;
-    if (wheelHeight <= 0) {
+    const optionHeight = firstOption.offsetHeight || 0;
+    if (optionHeight <= 0) {
       return;
     }
-    const optionHeight = firstOption.offsetHeight || 0;
-    const padding = Math.max(0, wheelHeight / 2 - optionHeight / 2);
+    const padding = Math.max(0, (optionHeight * VISIBLE_ROWS) / 2 - optionHeight / 2);
     wheel.style.setProperty('--wheel-padding', `${padding}px`);
   }, []);
 
@@ -326,79 +781,105 @@ function WheelColumn<Option extends string>({
     return () => window.removeEventListener('resize', handleResize);
   }, [updateWheelPadding]);
 
-  useEffect(() => {
-    return () => {
-      if (scrollTimeoutRef.current !== null) {
-        window.clearTimeout(scrollTimeoutRef.current);
+  useEffect(() => () => {
+    if (scrollTimeoutRef.current !== null) {
+      window.clearTimeout(scrollTimeoutRef.current);
+    }
+  }, []);
+
+  const scrollToOption = useCallback(
+    (index: number, behavior: ScrollBehavior = 'smooth') => {
+      const wheel = wheelRef.current;
+      const optionNode = optionRefs.current[index];
+      if (!wheel || !optionNode) {
+        return;
       }
-    };
-  }, []);
+      const wheelHeight = wheel.clientHeight;
+      const optionOffsetTop = optionNode.offsetTop;
+      const optionHeight = optionNode.offsetHeight;
+      const targetScrollTop = optionOffsetTop - wheelHeight / 2 + optionHeight / 2;
+      programmaticScrollRef.current = true;
+      if (typeof wheel.scrollTo === 'function') {
+        wheel.scrollTo({ top: targetScrollTop, behavior });
+      } else {
+        wheel.scrollTop = targetScrollTop;
+      }
+      if (behavior === 'auto') {
+        programmaticScrollRef.current = false;
+      }
+    },
+    [],
+  );
 
-  const scrollToOption = useCallback((index: number, behavior: ScrollBehavior = 'smooth') => {
-    const wheel = wheelRef.current;
-    const optionNode = optionRefs.current[index];
-    if (!wheel || !optionNode) {
-      return;
-    }
-
-    const wheelHeight = wheel.clientHeight;
-    const optionOffsetTop = optionNode.offsetTop;
-    const optionHeight = optionNode.offsetHeight;
-    const targetScrollTop = optionOffsetTop - wheelHeight / 2 + optionHeight / 2;
-
-    programmaticScrollRef.current = true;
-    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
-    lastScrollInfoRef.current = {
-      top: targetScrollTop,
-      timestamp: now,
-      velocity: 0,
-    };
-    if (typeof wheel.scrollTo === 'function') {
-      wheel.scrollTo({ top: targetScrollTop, behavior });
-    } else {
-      wheel.scrollTop = targetScrollTop;
-    }
-    if (behavior === 'auto') {
-      programmaticScrollRef.current = false;
-    }
-  }, []);
+  const findClosestEnabledIndex = useCallback(
+    (startIndex: number) => {
+      if (options.length === 0) {
+        return -1;
+      }
+      if (!options[startIndex]?.disabled) {
+        return startIndex;
+      }
+      for (let offset = 1; offset < options.length; offset += 1) {
+        const before = startIndex - offset;
+        if (before >= 0 && !options[before]?.disabled) {
+          return before;
+        }
+        const after = startIndex + offset;
+        if (after < options.length && !options[after]?.disabled) {
+          return after;
+        }
+      }
+      return -1;
+    },
+    [options],
+  );
 
   const handleOptionSelect = useCallback(
-    (option: Option) => {
+    (option: string) => {
       if (disabled) {
         return;
       }
-      if (option === selected) {
-        const existingIndex = options.indexOf(option);
-        if (existingIndex >= 0) {
-          scrollToOption(existingIndex);
-        }
+      const index = options.findIndex((item) => item.value === option);
+      if (index < 0) {
         return;
       }
-
-      onSelect(option);
-      const selectedIndex = options.indexOf(option);
-      if (selectedIndex >= 0) {
-        scrollToOption(selectedIndex);
+      if (options[index]?.disabled) {
+        return;
       }
+      onSelect(option);
+      scrollToOption(index);
+      onSnap?.();
     },
-    [disabled, onSelect, options, scrollToOption, selected],
+    [disabled, onSelect, onSnap, options, scrollToOption],
   );
 
   const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
+    (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
       if (disabled) {
         return;
       }
-
+      const moveFocus = (step: number) => {
+        let nextIndex = index;
+        do {
+          nextIndex = (nextIndex + step + options.length) % options.length;
+        } while (options[nextIndex]?.disabled && nextIndex !== index);
+        if (!options[nextIndex]?.disabled) {
+          handleOptionSelect(options[nextIndex].value);
+          optionRefs.current[nextIndex]?.focus();
+        }
+      };
       if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
         event.preventDefault();
-        const nextIndex = currentIndex === 0 ? options.length - 1 : currentIndex - 1;
-        handleOptionSelect(options[nextIndex]);
+        moveFocus(-1);
       } else if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
         event.preventDefault();
-        const nextIndex = currentIndex === options.length - 1 ? 0 : currentIndex + 1;
-        handleOptionSelect(options[nextIndex]);
+        moveFocus(1);
+      } else if (event.key === 'PageUp') {
+        event.preventDefault();
+        moveFocus(-VISIBLE_ROWS);
+      } else if (event.key === 'PageDown') {
+        event.preventDefault();
+        moveFocus(VISIBLE_ROWS);
       }
     },
     [disabled, handleOptionSelect, options],
@@ -409,12 +890,10 @@ function WheelColumn<Option extends string>({
     if (!wheel || options.length === 0) {
       return;
     }
-
     const { top, height } = wheel.getBoundingClientRect();
     const centerY = top + height / 2;
     let closestIndex = -1;
     let shortestDistance = Number.POSITIVE_INFINITY;
-
     optionRefs.current.forEach((node, index) => {
       if (!node) {
         return;
@@ -427,70 +906,51 @@ function WheelColumn<Option extends string>({
         closestIndex = index;
       }
     });
-
     if (closestIndex >= 0) {
-      const nextOption = options[closestIndex];
-      if (nextOption !== selected) {
-        handleOptionSelect(nextOption);
-      } else {
-        scrollToOption(closestIndex);
+      const nearestEnabled = findClosestEnabledIndex(closestIndex);
+      if (nearestEnabled >= 0) {
+        const nextOption = options[nearestEnabled];
+        if (nextOption.value !== selected) {
+          onSelect(nextOption.value);
+        }
+        scrollToOption(nearestEnabled);
+        onSnap?.();
       }
     }
-  }, [handleOptionSelect, options, scrollToOption, selected]);
+  }, [findClosestEnabledIndex, onSelect, onSnap, options, scrollToOption, selected]);
 
   const handleScroll = useCallback(() => {
     if (disabled || !wheelRef.current || options.length === 0) {
       return;
     }
-
     if (scrollTimeoutRef.current !== null) {
       window.clearTimeout(scrollTimeoutRef.current);
     }
-
-    const wheel = wheelRef.current;
-    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
-    const currentTop = wheel.scrollTop;
-    const last = lastScrollInfoRef.current;
-    const deltaTime = Math.max(1, now - last.timestamp);
-    const velocity = (currentTop - last.top) / deltaTime;
-    lastScrollInfoRef.current = {
-      top: currentTop,
-      timestamp: now,
-      velocity,
-    };
-
     const attemptSettle = () => {
       if (programmaticScrollRef.current) {
         programmaticScrollRef.current = false;
         return;
       }
-
-      const nowCheck = typeof performance !== 'undefined' ? performance.now() : Date.now();
-      const timeSinceLastScroll = nowCheck - lastScrollInfoRef.current.timestamp;
-      const latestVelocity = Math.abs(lastScrollInfoRef.current.velocity);
-      if (timeSinceLastScroll < 120 && latestVelocity > 0.05) {
-        scrollTimeoutRef.current = window.setTimeout(attemptSettle, 80);
-        return;
-      }
-
       finalizeScroll();
     };
-
-    scrollTimeoutRef.current = window.setTimeout(attemptSettle, 140);
-  }, [disabled, finalizeScroll, options]);
+    scrollTimeoutRef.current = window.setTimeout(attemptSettle, 120);
+  }, [disabled, finalizeScroll, options.length]);
 
   useEffect(() => {
     if (options.length === 0) {
       return;
     }
-    const nextIndex = selected ? options.indexOf(selected) : 0;
-    if (nextIndex < 0) {
+    let targetIndex = options.findIndex((option) => option.value === selected);
+    if (targetIndex < 0) {
+      targetIndex = findClosestEnabledIndex(0);
+    }
+    if (targetIndex < 0) {
       return;
     }
     const behavior = isInitialRenderRef.current ? 'auto' : 'smooth';
     isInitialRenderRef.current = false;
-    scrollToOption(nextIndex, behavior);
-  }, [options, scrollToOption, selected]);
+    scrollToOption(targetIndex, behavior);
+  }, [findClosestEnabledIndex, options, scrollToOption, selected]);
 
   const registerOptionRef = useCallback(
     (index: number) => (node: HTMLButtonElement | null) => {
@@ -505,34 +965,37 @@ function WheelColumn<Option extends string>({
   return (
     <div
       className="patrol-code-input__wheel"
-      role="radiogroup"
+      role="listbox"
       aria-label={ariaLabel}
       aria-disabled={disabled || undefined}
       ref={wheelRef}
       onScroll={handleScroll}
     >
       {options.map((option, index) => {
-        const isSelected = selected === option;
+        const isSelected = selected === option.value;
+        const optionId = `${ariaLabel.replace(/\s+/g, '-').toLowerCase()}-${option.value}`;
         const className = [
           'patrol-code-input__wheel-option',
           isSelected ? 'patrol-code-input__wheel-option--selected' : '',
         ]
           .filter(Boolean)
           .join(' ');
-
         return (
           <button
+            key={option.value}
             type="button"
-            role="radio"
-            aria-checked={isSelected}
-            key={option}
+            id={optionId}
+            role="option"
+            aria-selected={isSelected}
+            aria-disabled={option.disabled || disabled || undefined}
             className={className}
-            onClick={() => handleOptionSelect(option)}
+            onClick={() => handleOptionSelect(option.value)}
             onKeyDown={(event) => handleKeyDown(event, index)}
-            disabled={disabled}
+            disabled={disabled || option.disabled}
             ref={registerOptionRef(index)}
+            title={option.title}
           >
-            {option}
+            {option.label}
           </button>
         );
       })}


### PR DESCRIPTION
## Summary
- replace the manual patrol code input with a backend-driven picker that snaps, validates combinations, and exposes a text fallback
- add haptic feedback, accessibility tweaks, and availability telemetry while updating styles to show the shared highlight band
- adjust patrol loading logic and tests to support the new picker contracts and category restrictions

## Testing
- npm run lint
- npm run test -- --run tests

------
https://chatgpt.com/codex/tasks/task_e_68de4dcd2e388326bee0730e4bfca366