### PR TITLE
Soften hero card shadows

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -58,7 +58,7 @@ body {
   display: grid;
   place-items: center;
   padding: 12px;
-  box-shadow: 0 18px 34px rgba(15, 118, 110, 0.28);
+  box-shadow: 0 8px 18px rgba(15, 118, 110, 0.24);
 }
 
 .hero-logo img {
@@ -255,7 +255,7 @@ body {
   padding: 12px 16px;
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.86);
-  box-shadow: 0 12px 24px rgba(11, 83, 70, 0.15);
+  box-shadow: 0 6px 16px rgba(11, 83, 70, 0.18);
   border: 1px solid rgba(11, 83, 70, 0.12);
 }
 


### PR DESCRIPTION
## Summary
- reduce the drop shadow on the hero logo so the badge feels less detached from the background
- tone down the offline queue card shadow to keep the panel visually anchored

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de544591b48326ba865f80209788ff