### PR TITLE
Adjust category grid responsiveness

### DIFF
--- a/web/src/scoreboard/ScoreboardApp.css
+++ b/web/src/scoreboard/ScoreboardApp.css
@@ -223,12 +223,12 @@ body {
   background: #ffffff;
   border-radius: 28px;
   box-shadow: 0 28px 60px rgba(17, 24, 39, 0.12);
-  padding: 32px 28px;
+  padding: clamp(24px, 3vw, 48px);
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: clamp(20px, 3vw, 32px);
   width: 100%;
-  max-width: 960px;
+  max-width: 1280px;
 }
 
 .scoreboard-section-header {
@@ -265,8 +265,8 @@ body {
 
 .scoreboard-groups {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(16px, 2.5vw, 32px);
 }
 
 .scoreboard-group {


### PR DESCRIPTION
## Summary
- relax the scoreboard category grid to allow more columns on wide screens
- increase internal padding and responsive gaps to keep space between groups and the section edges

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de551901048326b22dd889c8b352bb