### PR TITLE
Enhance wheel haptics and snapping behaviour

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,7 +24,7 @@ import { createTicket, loadTickets, saveTickets, transitionTicket, Ticket, Ticke
 import { registerPendingSync, setupSyncListener } from './backgroundSync';
 import { appendScanRecord } from './storage/scanHistory';
 import { computePureCourseSeconds, computeTimePoints, isTimeScoringCategory } from './timeScoring';
-import { triggerConfirmationHaptic } from './utils/haptics';
+import { triggerHaptic } from './utils/haptics';
 
 
 interface Patrol {
@@ -2157,7 +2157,7 @@ function StationApp({
                       code: manualValidation.code,
                       patrolId: manualValidation.patrolId,
                     });
-                    triggerConfirmationHaptic();
+                    triggerHaptic('heavy');
                     void fetchPatrol(manualValidation.code.trim());
                   }}
                   disabled={!manualValidation.valid || patrolRegistryLoading}


### PR DESCRIPTION
## Summary
- introduce a unified `triggerHaptic` helper that respects platform capabilities, reduced motion, and telemetry
- add live scroll tracking, throttled tick feedback, and delayed centring snaps for the points and patrol code wheels
- trigger medium confirmation haptics on automatic snaps and heavy feedback when confirming a patrol load

## Testing
- npm run lint
- npm test *(fails: vitest environment lacks supabase order mock)*

------
https://chatgpt.com/codex/tasks/task_e_68de5d34834483269e5d423673f759fb