### PR TITLE
Remove hyphen between category and gender in patrol code display

### DIFF
--- a/web/src/components/PatrolCodeInput.tsx
+++ b/web/src/components/PatrolCodeInput.tsx
@@ -103,14 +103,14 @@ function formatDisplayValue(normalised: string) {
   }
   const fullMatch = normalised.match(/^([NMSR])([HD])-(\d{1,2})$/);
   if (fullMatch) {
-    return `${fullMatch[1]}-${fullMatch[2]}-${fullMatch[3].padStart(2, '0')}`;
+    return `${fullMatch[1]}${fullMatch[2]}-${fullMatch[3].padStart(2, '0')}`;
   }
   const partialGender = normalised.match(/^([NMSR])([HD])$/);
   if (partialGender) {
-    return `${partialGender[1]}-${partialGender[2]}`;
+    return `${partialGender[1]}${partialGender[2]}`;
   }
   if (/^([NMSR])([HD])-$/.test(normalised)) {
-    return `${normalised[0]}-${normalised[1]}-`;
+    return `${normalised[0]}${normalised[1]}-`;
   }
   if (/^([NMSR])-$/.test(normalised)) {
     return `${normalised[0]}-`;
@@ -541,7 +541,7 @@ export default function PatrolCodeInput({
           onChange={handleFallbackChange}
           onFocus={handleFallbackFocus}
           onBlur={handleFallbackBlur}
-          placeholder="N-H-07"
+          placeholder="NH-07"
           aria-describedby={feedbackId}
           aria-invalid={!validationState.valid}
         />


### PR DESCRIPTION
## Summary
- update the patrol code display formatter so category and gender render without an intervening hyphen
- adjust the manual entry placeholder text to reflect the new patrol code format

## Testing
- npm test -- --run *(fails: Supabase query mock lacks `order` method in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de75d1837c83268be30f39e7dda14c