### PR TITLE
Add manual fallback input to points picker

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -675,7 +675,16 @@ body {
 
 .points-input__fallback {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.points-input__fallback label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(11, 83, 70, 0.7);
 }
 
 .points-input__fallback input {

--- a/web/src/components/PointsInput.tsx
+++ b/web/src/components/PointsInput.tsx
@@ -99,6 +99,7 @@ const PointsInput = forwardRef<HTMLButtonElement, PointsInputProps>(function Poi
   const inputId = id ?? generatedId;
   const labelId = label ? `${inputId}-label` : undefined;
   const helperId = `${inputId}-helper`;
+  const fallbackId = `${inputId}-fallback`;
 
   const options = useMemo(() => {
     return Array.from(
@@ -458,6 +459,8 @@ const PointsInput = forwardRef<HTMLButtonElement, PointsInputProps>(function Poi
     ? formatPointsForScreenReaders(Number(selectedOption))
     : 'Bez výběru';
 
+  const showWheel = !prefersReducedMotion;
+
   return (
     <div className="points-input">
       {label ? (
@@ -465,23 +468,7 @@ const PointsInput = forwardRef<HTMLButtonElement, PointsInputProps>(function Poi
           {label}
         </span>
       ) : null}
-      {prefersReducedMotion ? (
-        <div className="points-input__fallback">
-          <input
-            id={inputId}
-            type="number"
-            inputMode="numeric"
-            min={resolvedMin}
-            max={resolvedMax}
-            value={selectedOption}
-            onChange={handleFallbackChange}
-            aria-describedby={helperId}
-            aria-labelledby={labelId}
-            placeholder="—"
-            step={1}
-          />
-        </div>
-      ) : (
+      {showWheel ? (
         <div className="points-input__wheel-group">
           <div
             className="points-input__wheel"
@@ -521,7 +508,23 @@ const PointsInput = forwardRef<HTMLButtonElement, PointsInputProps>(function Poi
             })}
           </div>
         </div>
-      )}
+      ) : null}
+      <div className="points-input__fallback">
+        <label htmlFor={fallbackId}>Zadat body ručně</label>
+        <input
+          id={fallbackId}
+          type="number"
+          inputMode="numeric"
+          min={resolvedMin}
+          max={resolvedMax}
+          value={value || ''}
+          onChange={handleFallbackChange}
+          aria-describedby={helperId}
+          aria-labelledby={labelId}
+          placeholder="—"
+          step={1}
+        />
+      </div>
       <div className="points-input__value" aria-live="polite">
         <strong>
           <span className="points-input__value-number">{displayNumber}</span>


### PR DESCRIPTION
## Summary
- add an always-available manual input field to the points picker so it mirrors the patrol loading workflow
- tweak the fallback styling to accommodate the new label and layout

## Testing
- npm test -- src/__tests__/stationFlow.test.tsx *(fails: supabase mock does not implement `order` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de796a2648832691d82a9ce39e83aa