### PR TITLE
Add visual separation for manual points input

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -678,6 +678,10 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 6px;
+  width: 100%;
+  padding-top: 16px;
+  margin-top: 12px;
+  border-top: 1px solid rgba(11, 83, 70, 0.18);
 }
 
 .points-input__fallback label {


### PR DESCRIPTION
## Summary
- add spacing and a subtle divider above the manual points input fallback to separate it from the wheel selector

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de7fe8f184832699667f6fb176e474