### PR TITLE
Narrow points wheel and remove manual entry

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -512,8 +512,8 @@ body {
     (var(--points-wheel-item-height) * var(--points-wheel-visible-count) - var(--points-wheel-item-height)) /
       2
   );
-  min-width: 96px;
-  max-width: 128px;
+  min-width: 80px;
+  max-width: 104px;
   height: calc(var(--points-wheel-item-height) * var(--points-wheel-visible-count) + 16px);
   min-height: calc(var(--points-wheel-item-height) * var(--points-wheel-visible-count) + 16px);
   max-height: calc(var(--points-wheel-item-height) * var(--points-wheel-visible-count) + 16px);
@@ -671,44 +671,6 @@ body {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(10, 66, 54, 0.72);
-}
-
-.points-input__fallback {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  padding-top: 16px;
-  margin-top: 12px;
-  border-top: 1px solid rgba(11, 83, 70, 0.18);
-}
-
-.points-input__fallback label {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(11, 83, 70, 0.7);
-}
-
-.points-input__fallback input {
-  width: 100%;
-  max-width: 128px;
-  border-radius: 12px;
-  border: 1px solid rgba(11, 83, 70, 0.18);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 12px 32px rgba(10, 66, 54, 0.14);
-  font-size: 1.125rem;
-  font-weight: 600;
-  line-height: 1;
-  padding: 12px 16px;
-  text-align: center;
-  color: #0b5346;
-}
-
-.points-input__fallback input:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px rgba(13, 124, 84, 0.35);
 }
 
 .points-input__actions {

--- a/web/src/components/PointsInput.tsx
+++ b/web/src/components/PointsInput.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
-import type { ChangeEvent, KeyboardEvent, MutableRefObject } from 'react';
+import type { KeyboardEvent, MutableRefObject } from 'react';
 import { triggerHaptic } from '../utils/haptics';
 
 type PointsOption = string;
@@ -99,7 +99,6 @@ const PointsInput = forwardRef<HTMLButtonElement, PointsInputProps>(function Poi
   const inputId = id ?? generatedId;
   const labelId = label ? `${inputId}-label` : undefined;
   const helperId = `${inputId}-helper`;
-  const fallbackId = `${inputId}-fallback`;
 
   const options = useMemo(() => {
     return Array.from(
@@ -463,25 +462,6 @@ const PointsInput = forwardRef<HTMLButtonElement, PointsInputProps>(function Poi
     [focusIndex, setFocusRef],
   );
 
-  const handleFallbackChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const nextValue = event.target.value;
-      if (nextValue === '') {
-        onChange('');
-        return;
-      }
-
-      const parsed = Number.parseInt(nextValue, 10);
-      if (!Number.isInteger(parsed)) {
-        return;
-      }
-
-      const clamped = Math.min(resolvedMax, Math.max(resolvedMin, parsed));
-      onChange(String(clamped));
-    },
-    [onChange, resolvedMax, resolvedMin],
-  );
-
   const selectedForScreenReader = selectedOption
     ? formatPointsForScreenReaders(Number(selectedOption))
     : 'Bez výběru';
@@ -536,22 +516,6 @@ const PointsInput = forwardRef<HTMLButtonElement, PointsInputProps>(function Poi
           </div>
         </div>
       ) : null}
-      <div className="points-input__fallback">
-        <label htmlFor={fallbackId}>Zadat body ručně</label>
-        <input
-          id={fallbackId}
-          type="number"
-          inputMode="numeric"
-          min={resolvedMin}
-          max={resolvedMax}
-          value={value || ''}
-          onChange={handleFallbackChange}
-          aria-describedby={helperId}
-          aria-labelledby={labelId}
-          placeholder="—"
-          step={1}
-        />
-      </div>
       <div className="points-input__value" aria-live="polite">
         <strong>
           <span className="points-input__value-number">{displayNumber}</span>


### PR DESCRIPTION
## Summary
- narrow the points selector wheel to better match the surrounding layout
- remove the manual points fallback input and its supporting styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dec3e8645c8326834d13ace4c16b9c