### PR TITLE
Nastav základní URL aplikace na /setonuv-zavod

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,14 @@ Server poskytuje endpointy:
 - Správné odpovědi lze hromadně upravit v horním panelu (vyžaduje administrátorský
   režim). Při zapnutí automatického hodnocení se odpovědi validují (12 otázek,
   pouze písmena A–D).
+- Přihlašovací obrazovka a hlavní rozhraní jsou dostupné na adrese
+  `/setonuv-zavod`.
 - Každé stanoviště má vlastní URL tvaru
   `/setonuv-zavod/stanoviste/<station_id>` (s krátkým aliasem
-  `/stanoviste/<station_id>` a zpětně kompatibilním `/stations/<station_id>`);
-  aktuálně probíhající instalace je dostupná i na prefixu `/setonuv-zavod`.
-  Pro výsledkový přehled existuje krátká adresa `/vysledky` a zkrácený přepis
-  `/setonuv-zavod/vysledky` (starší `/scoreboard` a `/setonuv-zavod/scoreboard`
-  zůstávají funkční).
+  `/stanoviste/<station_id>` a zpětně kompatibilním `/stations/<station_id>`).
+- Výsledkový přehled má kanonickou adresu `/setonuv-zavod/vysledky`;
+  zachovány jsou i zkrácené aliasy `/vysledky`, `/scoreboard` a
+  `/setonuv-zavod/scoreboard`.
 
 ## Uživatelský manuál
 

--- a/docs/USER_GUIDE.cs.md
+++ b/docs/USER_GUIDE.cs.md
@@ -6,8 +6,8 @@ praktický návod pro provoz na stanovišti i pro kancelář závodu.
 
 ## 1. Přístup a přihlášení
 
-1. Otevři adresu nasazené aplikace. Aplikace běží jako PWA a po prvním načtení
-   funguje i bez připojení.
+1. Otevři `/setonuv-zavod` (nasazená instance může mít i vlastní doménu).
+   Aplikace běží jako PWA a po prvním načtení funguje i bez připojení.
 2. Zadej e-mail a heslo rozhodčího. Přístupové údaje spravuje hlavní rozhodčí.
 3. Volitelně můžeš při přihlášení nastavit vlastní PIN (4–6 číslic). PIN se uloží
    jen lokálně do prohlížeče a umožní zařízení odemknout bez zadávání hesla.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,7 @@ import { registerPendingSync, setupSyncListener } from './backgroundSync';
 import { appendScanRecord } from './storage/scanHistory';
 import { computePureCourseSeconds, computeTimePoints, isTimeScoringCategory } from './timeScoring';
 import { triggerHaptic } from './utils/haptics';
+import { ROUTE_PREFIX } from './routing';
 
 
 interface Patrol {
@@ -2614,7 +2615,7 @@ export function useStationRouting(status: AuthStatus) {
       status.state === 'error'
     ) {
       if (isStationAppPath(pathname)) {
-        window.history.replaceState(window.history.state, '', '/');
+        window.history.replaceState(window.history.state, '', ROUTE_PREFIX);
       }
     }
   }, [status]);

--- a/web/src/__tests__/stationRouting.test.tsx
+++ b/web/src/__tests__/stationRouting.test.tsx
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type { AuthStatus } from '../auth/types';
-import { getStationPath } from '../routing';
+import { getStationPath, ROUTE_PREFIX } from '../routing';
 
 let useStationRouting: (status: AuthStatus) => void;
 
@@ -15,7 +15,7 @@ beforeAll(async () => {
 
 describe('useStationRouting', () => {
   beforeEach(() => {
-    window.history.replaceState({}, '', '/');
+    window.history.replaceState({}, '', ROUTE_PREFIX);
   });
 
   it('redirects to station path after authentication', () => {
@@ -90,6 +90,6 @@ describe('useStationRouting', () => {
 
     rerender({ status: unauthStatus });
 
-    expect(window.location.pathname).toBe('/');
+    expect(window.location.pathname).toBe(ROUTE_PREFIX);
   });
 });

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -30,6 +30,10 @@
       "destination": "https://vdkbdnxkpeeqxnruwiah.supabase.co/functions/v1/$1"
     },
     {
+      "source": "/setonuv-zavod",
+      "destination": "/"
+    },
+    {
       "source": "/setonuv-zavod/stanoviste",
       "destination": "/"
     },


### PR DESCRIPTION
## Summary
- redirect the login flow to live under the `/setonuv-zavod` prefix and update the Vercel rewrite to serve that path
- document the new canonical URLs for the login and scoreboard views in the README and user guide
- align the routing tests and station workflow mocks with the new prefix so they continue to exercise the updated paths

## Testing
- `npm test -- --run src/__tests__/stationRouting.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68dec1fe31f08326948582aa227f301c