### PR TITLE
Adjust hero logo badge proportions

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -51,13 +51,13 @@ body {
 }
 
 .hero-logo {
-  width: 96px;
-  height: 96px;
-  border-radius: 28px;
+  width: 88px;
+  height: 88px;
+  border-radius: 24px;
   background: rgba(255, 255, 255, 0.12);
   display: grid;
   place-items: center;
-  padding: 12px;
+  padding: 10px;
   box-shadow: 0 8px 18px rgba(15, 118, 110, 0.24);
 }
 

--- a/web/src/scoreboard/ScoreboardApp.css
+++ b/web/src/scoreboard/ScoreboardApp.css
@@ -47,13 +47,13 @@ body {
 }
 
 .scoreboard-hero-logo {
-  width: 96px;
-  height: 96px;
-  border-radius: 28px;
+  width: 88px;
+  height: 88px;
+  border-radius: 24px;
   background: rgba(255, 255, 255, 0.12);
   display: grid;
   place-items: center;
-  padding: 12px;
+  padding: 10px;
   box-shadow: 0 18px 34px rgba(15, 118, 110, 0.28);
 }
 


### PR DESCRIPTION
## Summary
- reduce the hero logo badge dimensions and padding in the station view to tighten the surrounding oval
- mirror the adjusted logo badge sizing in the scoreboard view for consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dec433dc4c8326ba7e8efe5ced95c8