### PR TITLE
Update queue reset to only clear completed patrols

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1117,13 +1117,18 @@ function StationApp({
   );
 
   const handleResetTickets = useCallback(() => {
-    let hadTickets = false;
-    updateTickets((current) => {
-      hadTickets = current.length > 0;
-      return [];
-    });
-    if (hadTickets) {
-      pushAlert('Fronta byla vymazána.');
+    let removedTickets = 0;
+    updateTickets((current) =>
+      current.filter((ticket) => {
+        const keep = ticket.state !== 'done';
+        if (!keep) {
+          removedTickets += 1;
+        }
+        return keep;
+      }),
+    );
+    if (removedTickets > 0) {
+      pushAlert('Dokončené hlídky byly odebrány z fronty.');
     }
   }, [pushAlert, updateTickets]);
 

--- a/web/src/components/TicketQueue.tsx
+++ b/web/src/components/TicketQueue.tsx
@@ -61,7 +61,7 @@ export default function TicketQueue({ tickets, onChangeState, onReset, heartbeat
         </div>
         <div className="card-actions">
           <button type="button" className="ghost" onClick={onReset}>
-            Resetovat frontu
+            Odebrat dokončené hlídky
           </button>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- only remove tickets in the done state when resetting the queue
- rename the reset button to reflect that only completed patrols are removed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e3fbb9208326a09371090a9c009e