### PR TITLE
Make logos link to zelenaliga.cz

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1674,6 +1674,7 @@ textarea {
   place-items: center;
   padding: 12px;
   box-shadow: 0 18px 34px rgba(15, 118, 110, 0.28);
+  text-decoration: none;
 }
 
 .auth-hero-logo img {

--- a/web/src/auth/ChangePasswordScreen.tsx
+++ b/web/src/auth/ChangePasswordScreen.tsx
@@ -60,9 +60,14 @@ export default function ChangePasswordScreen({ email, judgeId, pendingPin }: Pro
       <div className="auth-shell-content">
         <div className="auth-layout">
           <div className="auth-hero">
-            <div className="auth-hero-logo">
+            <a
+              className="auth-hero-logo"
+              href="https://zelenaliga.cz"
+              target="_blank"
+              rel="noreferrer"
+            >
               <img src={zelenaLigaLogo} alt="Logo Setonův závod" />
-            </div>
+            </a>
             <div className="auth-hero-copy">
               <span className="auth-hero-eyebrow">Setonův závod</span>
               <h1>Obnova přístupu</h1>

--- a/web/src/auth/LoginScreen.tsx
+++ b/web/src/auth/LoginScreen.tsx
@@ -83,9 +83,14 @@ export default function LoginScreen({ requirePinOnly }: Props) {
       <div className="auth-shell-content">
         <div className="auth-layout">
           <div className="auth-hero">
-            <div className="auth-hero-logo">
+            <a
+              className="auth-hero-logo"
+              href="https://zelenaliga.cz"
+              target="_blank"
+              rel="noreferrer"
+            >
               <img src={zelenaLigaLogo} alt="Logo Setonův závod" />
-            </div>
+            </a>
             <div className="auth-hero-copy">
               <span className="auth-hero-eyebrow">Setonův závod</span>
               <h1>{heroTitle}</h1>

--- a/web/src/homepage/Homepage.css
+++ b/web/src/homepage/Homepage.css
@@ -24,6 +24,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  text-decoration: none;
 }
 
 .homepage-hero-logo img {

--- a/web/src/homepage/Homepage.tsx
+++ b/web/src/homepage/Homepage.tsx
@@ -30,9 +30,15 @@ function Homepage() {
   return (
     <div className="homepage-shell">
       <header className="homepage-hero">
-        <div className="homepage-hero-logo" aria-hidden="true">
+        <a
+          className="homepage-hero-logo"
+          href="https://zelenaliga.cz"
+          target="_blank"
+          rel="noreferrer"
+          aria-hidden="true"
+        >
           <img src={logo} alt="Logo Zelená liga" />
-        </div>
+        </a>
         <div className="homepage-hero-copy">
           <p className="homepage-eyebrow">Zelená liga</p>
           <h1>Digitální podpora soutěží SPTO</h1>

--- a/web/src/scoreboard/ScoreboardApp.css
+++ b/web/src/scoreboard/ScoreboardApp.css
@@ -55,6 +55,7 @@ body {
   place-items: center;
   padding: 10px;
   box-shadow: 0 18px 34px rgba(15, 118, 110, 0.28);
+  text-decoration: none;
 }
 
 .scoreboard-hero-logo img {

--- a/web/src/scoreboard/ScoreboardApp.tsx
+++ b/web/src/scoreboard/ScoreboardApp.tsx
@@ -493,9 +493,14 @@ function ScoreboardApp() {
       <header className="scoreboard-hero">
         <div className="scoreboard-hero-top">
           <div className="scoreboard-hero-brand">
-            <div className="scoreboard-hero-logo">
+            <a
+              className="scoreboard-hero-logo"
+              href="https://zelenaliga.cz"
+              target="_blank"
+              rel="noreferrer"
+            >
               <img src={zelenaLigaLogo} alt="Logo Setonův závod" />
-            </div>
+            </a>
             <div>
               <span className="scoreboard-hero-eyebrow">Setonův závod</span>
               <h1>Výsledkový přehled</h1>


### PR DESCRIPTION
## Summary
- make the homepage, scoreboard, and auth screen logos link to https://zelenaliga.cz
- keep existing styling of the logo containers after switching to anchor elements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2e3acd9c48326ba50ac3969a75fec