### PR TITLE
Make station header logo link to Zelená liga

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1961,9 +1961,15 @@ function StationApp({
       <header className="hero">
         <div className="hero-inner">
           <div className="hero-brand">
-            <div className="hero-logo">
+            <a
+              className="hero-logo"
+              href="https://zelenaliga.cz"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Zelená liga"
+            >
               <img src={zelenaLigaLogo} alt="Logo Setonův závod" />
-            </div>
+            </a>
             <div>
               <h1>Setonův závod – stanoviště</h1>
               <p>Spravuj průběh Setonova závodu s automatickým hodnocením a offline frontou.</p>


### PR DESCRIPTION
## Summary
- make the Seton station header logo a link to zelenaliga.cz for quick navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e67cd66c83268516e6a6eb6ed889