### PR TITLE
Align homepage and auth footers with design

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1816,6 +1816,28 @@ textarea {
   transform: translateX(2px);
 }
 
+.auth-footer {
+  width: 100%;
+}
+
+.auth-footer .app-footer-content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(4px, 1.8vw, 8px);
+}
+
+.auth-footer .app-footer-logos {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(22px, 7vw, 56px);
+}
+
+.auth-footer .app-footer-logos img {
+  width: clamp(30px, 7vw, 42px);
+  height: auto;
+}
+
 .auth-card {
   background: var(--surface-alt);
   border-radius: clamp(1.5rem, 4vw, 1.75rem);

--- a/web/src/auth/ChangePasswordScreen.tsx
+++ b/web/src/auth/ChangePasswordScreen.tsx
@@ -150,7 +150,7 @@ export default function ChangePasswordScreen({ email, judgeId, pendingPin }: Pro
           </form>
         </div>
       </div>
-      <AppFooter className="auth-footer" />
+      <AppFooter className="app-footer--minimal auth-footer" />
     </div>
   );
 }

--- a/web/src/auth/LoginScreen.tsx
+++ b/web/src/auth/LoginScreen.tsx
@@ -297,7 +297,7 @@ export default function LoginScreen({ requirePinOnly }: Props) {
           </form>
         </div>
       </div>
-      <AppFooter className="auth-footer" />
+      <AppFooter className="app-footer--minimal auth-footer" />
     </div>
   );
 }

--- a/web/src/components/AppFooter.css
+++ b/web/src/components/AppFooter.css
@@ -13,6 +13,26 @@
   align-items: center;
 }
 
+.app-footer--minimal {
+  background: transparent;
+  border-top: none;
+  padding: clamp(32px, 5vw, 48px) clamp(20px, 6vw, 32px) clamp(48px, 7vw, 72px);
+  gap: clamp(16px, 4vw, 24px);
+  color: var(--text-muted);
+}
+
+.app-footer--minimal .app-footer-content {
+  gap: clamp(4px, 1.8vw, 8px);
+}
+
+.app-footer--minimal .app-footer-logos {
+  gap: clamp(22px, 7vw, 56px);
+}
+
+.app-footer--minimal .app-footer-logos img {
+  width: clamp(30px, 7vw, 42px);
+}
+
 .app-footer-content {
   display: flex;
   flex-direction: column;

--- a/web/src/scoreboard/ScoreboardApp.css
+++ b/web/src/scoreboard/ScoreboardApp.css
@@ -465,31 +465,24 @@
 
 .scoreboard-footer {
   margin-top: auto;
-  padding: 32px 24px 48px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  align-items: center;
-  text-align: center;
-  font-size: 0.9rem;
-  color: var(--text-muted);
+  width: 100%;
 }
 
 .scoreboard-footer .app-footer-content {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: clamp(4px, 1.8vw, 8px);
 }
 
 .scoreboard-footer .app-footer-logos {
   display: flex;
-  gap: 24px;
   align-items: center;
   justify-content: center;
+  gap: clamp(22px, 7vw, 56px);
 }
 
 .scoreboard-footer .app-footer-logos img {
-  width: 32px;
+  width: clamp(30px, 7vw, 42px);
   height: auto;
 }
 

--- a/web/src/scoreboard/ScoreboardApp.tsx
+++ b/web/src/scoreboard/ScoreboardApp.tsx
@@ -622,7 +622,7 @@ function ScoreboardApp() {
           )}
         </section>
       </main>
-      <AppFooter className="scoreboard-footer" />
+      <AppFooter className="app-footer--minimal scoreboard-footer" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a reusable minimal footer style that removes the bordered background
- update the homepage scoreboard and auth flows to use the unified footer layout
- tune spacing and logo sizing so the footer matches the provided design

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e536bf0e5c8326915e6032d4fae6cd