### PR TITLE
Unify footer styling with login appearance

### DIFF
--- a/web/src/auth/ChangePasswordScreen.tsx
+++ b/web/src/auth/ChangePasswordScreen.tsx
@@ -150,7 +150,7 @@ export default function ChangePasswordScreen({ email, judgeId, pendingPin }: Pro
           </form>
         </div>
       </div>
-      <AppFooter className="app-footer--minimal auth-footer" />
+      <AppFooter variant="minimal" className="auth-footer" />
     </div>
   );
 }

--- a/web/src/auth/LoginScreen.tsx
+++ b/web/src/auth/LoginScreen.tsx
@@ -297,7 +297,7 @@ export default function LoginScreen({ requirePinOnly }: Props) {
           </form>
         </div>
       </div>
-      <AppFooter className="app-footer--minimal auth-footer" />
+      <AppFooter variant="minimal" className="auth-footer" />
     </div>
   );
 }

--- a/web/src/components/AppFooter.css
+++ b/web/src/components/AppFooter.css
@@ -1,24 +1,19 @@
 .app-footer {
   margin-top: auto;
   width: 100%;
-  padding: 32px 24px 48px;
+  padding: clamp(32px, 5vw, 48px) clamp(20px, 6vw, 32px) clamp(48px, 7vw, 72px);
   text-align: center;
   font-size: 0.9rem;
-  color: var(--text-muted);
-  background: var(--surface);
-  border-top: 1px solid var(--border);
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: clamp(16px, 4vw, 24px);
   align-items: center;
 }
 
 .app-footer--minimal {
+  color: var(--text-muted);
   background: transparent;
   border-top: none;
-  padding: clamp(32px, 5vw, 48px) clamp(20px, 6vw, 32px) clamp(48px, 7vw, 72px);
-  gap: clamp(16px, 4vw, 24px);
-  color: var(--text-muted);
 }
 
 .app-footer--minimal .app-footer-content {
@@ -31,6 +26,25 @@
 
 .app-footer--minimal .app-footer-logos img {
   width: clamp(30px, 7vw, 42px);
+}
+
+.app-footer--dark {
+  color: rgba(245, 255, 242, 0.88);
+  background: transparent;
+  border-top: none;
+}
+
+.app-footer--dark .app-footer-content {
+  gap: clamp(4px, 1.8vw, 8px);
+}
+
+.app-footer--dark .app-footer-logos {
+  gap: clamp(22px, 7vw, 56px);
+}
+
+.app-footer--dark .app-footer-logos img {
+  width: clamp(30px, 7vw, 42px);
+  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.2));
 }
 
 .app-footer-content {
@@ -46,13 +60,13 @@
 
 .app-footer-logos {
   display: flex;
-  gap: clamp(18px, 6vw, 80px);
+  gap: clamp(22px, 7vw, 56px);
   align-items: center;
   justify-content: center;
 }
 
 .app-footer-logos img {
-  width: clamp(28px, 4vw, 32px);
+  width: clamp(30px, 7vw, 42px);
   height: auto;
   display: block;
   transition: transform 0.2s ease;

--- a/web/src/components/AppFooter.tsx
+++ b/web/src/components/AppFooter.tsx
@@ -4,10 +4,11 @@ import pionyrLogo from '../assets/pionyr1_vert_rgb.png';
 
 interface AppFooterProps {
   className?: string;
+  variant?: 'minimal' | 'dark';
 }
 
-export default function AppFooter({ className }: AppFooterProps) {
-  const classes = ['app-footer'];
+export default function AppFooter({ className, variant = 'minimal' }: AppFooterProps) {
+  const classes = ['app-footer', `app-footer--${variant}`];
 
   if (className) {
     classes.push(className);

--- a/web/src/scoreboard/ScoreboardApp.tsx
+++ b/web/src/scoreboard/ScoreboardApp.tsx
@@ -622,7 +622,7 @@ function ScoreboardApp() {
           )}
         </section>
       </main>
-      <AppFooter className="app-footer--minimal scoreboard-footer" />
+      <AppFooter variant="minimal" className="scoreboard-footer" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a variant prop to AppFooter so it defaults to the minimal login styling everywhere
- refresh footer CSS to use the login layout and support a dark overlay variant
- update auth and scoreboard screens to use the shared minimal footer variant

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53cbf352c8326a686d8bd439cb058