### PR TITLE
Adjust button shadows and clip rounded containers

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -109,6 +109,7 @@ body {
   align-items: center;
   text-align: center;
   color: var(--text);
+  overflow: clip;
 }
 
 .hero-panel-label {
@@ -224,7 +225,7 @@ body {
   text-decoration: none;
   letter-spacing: 0.02em;
   border: 1px solid rgba(255, 216, 79, 0.55);
-  box-shadow: 0 20px 46px rgba(52, 100, 60, 0.22);
+  box-shadow: 0 16px 34px rgba(52, 100, 60, 0.18);
   transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, color 0.2s ease,
     border-color 0.2s ease;
 }
@@ -241,11 +242,12 @@ body {
   color: var(--text);
   border-color: rgba(255, 204, 51, 0.7);
   transform: translateY(-1px) scale(1.01);
-  box-shadow: var(--focus-ring), 0 26px 50px rgba(52, 100, 60, 0.25);
+  box-shadow: 0 22px 42px rgba(52, 100, 60, 0.22);
 }
 
 .hero-panel-link:focus-visible {
   outline: none;
+  border-color: var(--py-blue);
 }
 
 .hero-panel-link:hover::after,
@@ -829,6 +831,15 @@ body {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  overflow: clip;
+}
+
+@supports not (overflow: clip) {
+  .hero-panel,
+  .card {
+    overflow: hidden;
+    -webkit-mask-image: -webkit-radial-gradient(white, black);
+  }
 }
 
 .card-header {
@@ -871,24 +882,25 @@ button {
   text-transform: uppercase;
   background: var(--zl-yellow);
   color: var(--text);
-  box-shadow: 0 18px 32px rgba(255, 216, 79, 0.3);
+  box-shadow: 0 12px 26px rgba(255, 216, 79, 0.22);
   transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease, border-color 0.2s ease;
 }
 
 button:hover {
   transform: translateY(-1px) scale(1.01);
   background: var(--zl-yellow-600);
-  box-shadow: 0 22px 36px rgba(255, 204, 51, 0.34);
+  box-shadow: 0 16px 30px rgba(255, 204, 51, 0.26);
 }
 
 button:focus-visible {
   outline: none;
-  box-shadow: var(--focus-ring);
+  box-shadow: none;
+  border-color: var(--py-blue);
 }
 
 button:active {
   transform: translateY(1px);
-  box-shadow: 0 4px 12px rgba(255, 216, 79, 0.24);
+  box-shadow: 0 6px 16px rgba(255, 216, 79, 0.18);
 }
 
 button:disabled {
@@ -914,13 +926,13 @@ button.primary {
 button.ghost {
   background: rgba(255, 216, 79, 0.16);
   color: var(--text);
-  border-color: rgba(255, 216, 79, 0.55);
-  box-shadow: 0 16px 30px rgba(255, 216, 79, 0.18);
+  border-color: rgba(255, 216, 79, 0.48);
+  box-shadow: 0 10px 22px rgba(255, 216, 79, 0.16);
 }
 
 button.ghost:hover {
   background: rgba(255, 204, 51, 0.28);
-  border-color: rgba(255, 204, 51, 0.7);
+  border-color: rgba(255, 204, 51, 0.62);
 }
 
 button:disabled {

--- a/web/src/scoreboard/ScoreboardApp.css
+++ b/web/src/scoreboard/ScoreboardApp.css
@@ -101,7 +101,7 @@
 }
 
 .scoreboard-button {
-  border: none;
+  border: 2px solid transparent;
   border-radius: 18px;
   padding: 14px 24px;
   font-weight: 700;
@@ -111,7 +111,7 @@
   cursor: pointer;
   background: var(--zl-yellow);
   color: var(--text);
-  box-shadow: 0 18px 32px rgba(255, 216, 79, 0.3);
+  box-shadow: 0 12px 26px rgba(255, 216, 79, 0.22);
   transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease, color 0.2s ease,
     border-color 0.2s ease;
 }
@@ -128,39 +128,42 @@
 .scoreboard-button--primary {
   background: var(--zl-yellow);
   color: var(--text);
-  box-shadow: 0 18px 32px rgba(255, 216, 79, 0.3);
+  box-shadow: 0 12px 26px rgba(255, 216, 79, 0.22);
 }
 
 .scoreboard-button--primary:not(:disabled):hover {
   background: var(--zl-yellow-600);
   transform: translateY(-1px);
-  box-shadow: 0 22px 36px rgba(255, 204, 51, 0.34);
+  box-shadow: 0 16px 30px rgba(255, 204, 51, 0.26);
 }
 
 .scoreboard-button--primary:focus-visible {
   outline: none;
-  box-shadow: var(--focus-ring), 0 22px 36px rgba(255, 204, 51, 0.34);
+  box-shadow: none;
+  border-color: rgba(0, 85, 164, 0.7);
 }
 
 .scoreboard-button--primary:not(:disabled):active {
   transform: translateY(1px);
-  box-shadow: 0 4px 12px rgba(255, 216, 79, 0.24);
+  box-shadow: 0 6px 16px rgba(255, 216, 79, 0.18);
 }
 
 .scoreboard-button--ghost {
   background: var(--py-blue);
   color: #ffffff;
-  box-shadow: 0 18px 32px rgba(0, 85, 164, 0.28);
+  box-shadow: 0 12px 26px rgba(0, 85, 164, 0.24);
 }
 
 .scoreboard-button--ghost:not(:disabled):hover {
   background: var(--py-blue-hover);
   transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(0, 85, 164, 0.26);
 }
 
 .scoreboard-button--ghost:focus-visible {
   outline: none;
-  box-shadow: var(--focus-ring), 0 18px 32px rgba(0, 85, 164, 0.28);
+  box-shadow: none;
+  border-color: rgba(255, 255, 255, 0.8);
 }
 
 .scoreboard-button--ghost:disabled {
@@ -170,7 +173,7 @@
 
 .scoreboard-button--ghost:not(:disabled):active {
   transform: translateY(1px);
-  box-shadow: 0 6px 18px rgba(0, 85, 164, 0.28);
+  box-shadow: 0 6px 18px rgba(0, 85, 164, 0.2);
 }
 
 .scoreboard-status {
@@ -317,6 +320,7 @@
   width: 100%;
   max-width: 1280px;
   border: 1px solid var(--border);
+  overflow: clip;
 }
 
 .scoreboard-section-header {
@@ -362,6 +366,15 @@
   border-radius: 18px;
   box-shadow: var(--shadow-soft);
   padding: 20px;
+  overflow: clip;
+}
+
+@supports not (overflow: clip) {
+  .scoreboard-section,
+  .scoreboard-group {
+    overflow: hidden;
+    -webkit-mask-image: -webkit-radial-gradient(white, black);
+  }
 }
 
 .scoreboard-group h3 {


### PR DESCRIPTION
## Summary
- add overflow clipping (with a fallback) to rounded panels and scoreboard sections that contain shadowed controls
- soften pill-style button shadows and replace glow focus rings with border-based highlighting
- reduce hero link and scoreboard button shadows to keep the styling consistent

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68e53f136ca88326ba70a12e6d5bf6e9