### PR TITLE
Reduce spacing above homepage benefits card

### DIFF
--- a/web/src/homepage/Homepage.css
+++ b/web/src/homepage/Homepage.css
@@ -266,7 +266,7 @@
 }
 
 .homepage-card {
-  margin: 32px 0;
+  margin: 20px 0;
   padding: 26px 30px;
   border-radius: 24px;
   background: rgba(255, 255, 255, 0.92);


### PR DESCRIPTION
## Summary
- decrease the top/bottom margin on the homepage benefit card to tighten the spacing under the yellow divider

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e542023bb48326bef13c3038cd9306