### PR TITLE
Remove duplicate border from points picker

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -549,7 +549,7 @@ body {
   align-items: center;
   padding: 8px 0 12px;
   border-radius: 16px;
-  border: 1px solid var(--border);
+  border: none;
   background: var(--surface);
   box-shadow: var(--shadow-soft);
   --points-wheel-item-height: 48px;


### PR DESCRIPTION
## Summary
- remove the outer border from the points picker so only the highlight ring remains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e542d522b08326ba2de2297552ae1f