### PR TITLE
Update login hero description text

### DIFF
--- a/web/src/auth/LoginScreen.tsx
+++ b/web/src/auth/LoginScreen.tsx
@@ -99,7 +99,7 @@ export default function LoginScreen({ requirePinOnly }: Props) {
   const heroTitle = requirePinOnly ? 'Stanoviště' : 'Rozhodčí';
   const heroDescription = requirePinOnly
     ? 'Odemkni uložené stanoviště Setonova závodu pomocí PINu a pokračuj i bez připojení.'
-    : 'Tady spravuješ svoje stanoviště, zapisuješ body a průběh hlídek. Aplikace funguje i bez signálu a po připojení vše sama synchronizuje.';
+    : 'Tady spravuješ průběh závodu na svém stanovišti. Zapisuj výsledky hlídek, kontroluj průchody a nech aplikaci, aby se o zbytek postarala. Když není signál, vše se uloží a po připojení se automaticky odešle.';
   const descriptionText = requirePinOnly
     ? 'Zadej PIN pro odemknutí uloženého stanoviště.'
     : 'Přihlašovací údaje získáš od hlavního rozhodčího.';


### PR DESCRIPTION
## Summary
- replace the default login hero description with the new Czech copy describing station duties

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68e543472110832682c0cdcaed18cc45