### PR TITLE
Update station hero description and restore login copy

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1972,7 +1972,10 @@ function StationApp({
             </a>
             <div>
               <h1>Setonův závod – stanoviště</h1>
-              <p>Spravuj průběh Setonova závodu s automatickým hodnocením a offline frontou.</p>
+              <p>
+                Tady spravuješ průběh závodu na svém stanovišti. Zapisuj výsledky hlídek, kontroluj průchody a nech aplikaci,
+                aby se o zbytek postarala. Když není signál, vše se uloží a po připojení se automaticky odešle.
+              </p>
             </div>
           </div>
           <div className="hero-meta">


### PR DESCRIPTION
## Summary
- restore the original login hero description for judges
- update the station hero banner text with the new copy about managing the checkpoint

## Testing
- not run (copy updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e543472110832682c0cdcaed18cc45