### PR TITLE
Adjust points wheel highlight width

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -582,7 +582,7 @@ body {
   top: 50%;
   left: 50%;
   height: var(--points-wheel-item-height);
-  width: calc(var(--points-wheel-width) - 16px);
+  width: calc(var(--points-wheel-width) - 4px);
   transform: translate(-50%, -50%);
   border-radius: 12px;
 }


### PR DESCRIPTION
## Summary
- expand the points input picker highlight so it spans nearly the full wheel width

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e545edace48326b023e73ce8d6726d