### PR TITLE
Center homepage footer logos

### DIFF
--- a/web/src/homepage/Homepage.css
+++ b/web/src/homepage/Homepage.css
@@ -246,11 +246,9 @@
 
 .homepage-footer-logos {
   display: flex;
-  gap: clamp(16px, 6vw, 96px);
-  align-items: center;
-  justify-content: space-between;
-  width: min(320px, 80%);
-  padding: 0 clamp(8px, 4vw, 16px);
+  gap: clamp(16px, 4vw, 40px);
+  align-items: flex-end;
+  justify-content: center;
 }
 
 .homepage-footer-logos img {


### PR DESCRIPTION
## Summary
- center the footer logos on the homepage and reduce excessive spacing so the icons sit side-by-side as intended

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54847f4388326b3505756650faeef