### PR TITLE
Hide podium patrols on scoreboard

### DIFF
--- a/web/src/scoreboard/ScoreboardApp.css
+++ b/web/src/scoreboard/ScoreboardApp.css
@@ -362,6 +362,8 @@
 .scoreboard-groups {
   display: grid;
   gap: clamp(18px, 2.4vw, 28px);
+  width: 100%;
+  grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
 }
 
 .scoreboard-group {
@@ -416,6 +418,13 @@
 
 .scoreboard-table tbody tr:nth-child(even) {
   background: #fffbe5;
+}
+
+.scoreboard-table-empty td {
+  padding: 16px 0 12px;
+  text-align: center;
+  font-weight: 600;
+  color: var(--text-muted);
 }
 
 .scoreboard-table tbody tr:nth-child(-n + 3)::before {

--- a/web/src/scoreboard/ScoreboardApp.tsx
+++ b/web/src/scoreboard/ScoreboardApp.tsx
@@ -48,6 +48,7 @@ interface RankedGroup {
   category: string;
   sex: string;
   items: RankedGroupItem[];
+  visibleItems: RankedGroupItem[];
 }
 
 const rawEventId = import.meta.env.VITE_EVENT_ID as string | undefined;
@@ -426,12 +427,17 @@ function ScoreboardApp() {
     });
 
     return Array.from(groups.values())
-      .map((group) => ({
-        ...group,
-        items: [...group.items]
+      .map((group) => {
+        const rankedItems = [...group.items]
           .sort(compareRankedResults)
-          .map((item, index) => ({ ...item, displayRank: index + 1 })),
-      }))
+          .map((item, index) => ({ ...item, displayRank: index + 1 }));
+        const visibleItems = rankedItems.filter((item) => item.displayRank > 3);
+        return {
+          ...group,
+          items: rankedItems,
+          visibleItems,
+        };
+      })
       .sort((a, b) => compareBrackets(a.category, a.sex, b.category, b.sex));
   }, [ranked]);
 
@@ -452,7 +458,7 @@ function ScoreboardApp() {
         const sheetName = formatCategoryLabel(group.category, group.sex);
         const rows = [
           ['#', 'Hlídka', 'Tým', 'Body', 'Body bez T'],
-          ...group.items.map((row) => {
+          ...group.visibleItems.map((row) => {
             const displayRank = row.displayRank > 0 ? row.displayRank : row.rankInBracket;
             const fallbackCode = createFallbackPatrolCode(group.category, group.sex, displayRank);
             return [
@@ -464,6 +470,9 @@ function ScoreboardApp() {
             ];
           }),
         ];
+        if (rows.length === 1) {
+          rows.push(['—', '—', 'Žádné výsledky mimo první tři místa.', '', '']);
+        }
         const worksheet = XLSX.utils.aoa_to_sheet(rows);
         XLSX.utils.book_append_sheet(workbook, worksheet, sheetName || '—');
       });
@@ -581,41 +590,51 @@ function ScoreboardApp() {
             <div className="scoreboard-placeholder">Načítám data…</div>
           ) : groupedRanked.length ? (
             <div className="scoreboard-groups">
-              {groupedRanked.map((group) => (
-                <div key={group.key} className="scoreboard-group">
-                  <h3>{formatCategoryLabel(group.category, group.sex)}</h3>
-                  <table className="scoreboard-table scoreboard-table--compact">
-                    <thead>
-                      <tr>
-                        <th>#</th>
-                        <th>Hlídka</th>
-                        <th>Body</th>
-                        <th>Body bez T</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {group.items.map((row) => {
-                        const displayRank = row.displayRank > 0 ? row.displayRank : row.rankInBracket;
-                        const fallbackCode = createFallbackPatrolCode(
-                          group.category,
-                          group.sex,
-                          displayRank,
-                        );
-                        return (
-                          <tr key={row.patrolId}>
-                            <td>{displayRank}</td>
-                            <td className="scoreboard-team">
-                              <strong>{formatPatrolNumber(row.patrolCode, fallbackCode)}</strong>
-                            </td>
-                            <td>{formatPoints(row.totalPoints)}</td>
-                            <td>{formatPoints(row.pointsNoT)}</td>
+              {groupedRanked.map((group) => {
+                const visibleRows = group.visibleItems;
+                return (
+                  <div key={group.key} className="scoreboard-group">
+                    <h3>{formatCategoryLabel(group.category, group.sex)}</h3>
+                    <table className="scoreboard-table scoreboard-table--compact">
+                      <thead>
+                        <tr>
+                          <th>#</th>
+                          <th>Hlídka</th>
+                          <th>Body</th>
+                          <th>Body bez T</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {visibleRows.length ? (
+                          visibleRows.map((row) => {
+                            const displayRank =
+                              row.displayRank > 0 ? row.displayRank : row.rankInBracket;
+                            const fallbackCode = createFallbackPatrolCode(
+                              group.category,
+                              group.sex,
+                              displayRank,
+                            );
+                            return (
+                              <tr key={row.patrolId}>
+                                <td>{displayRank}</td>
+                                <td className="scoreboard-team">
+                                  <strong>{formatPatrolNumber(row.patrolCode, fallbackCode)}</strong>
+                                </td>
+                                <td>{formatPoints(row.totalPoints)}</td>
+                                <td>{formatPoints(row.pointsNoT)}</td>
+                              </tr>
+                            );
+                          })
+                        ) : (
+                          <tr className="scoreboard-table-empty">
+                            <td colSpan={4}>Žádné výsledky mimo první tři místa.</td>
                           </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-              ))}
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                );
+              })}
             </div>
           ) : (
             <div className="scoreboard-placeholder">Zatím nejsou žádné výsledky.</div>


### PR DESCRIPTION
## Summary
- hide the first three ranked patrols from each category so the scoreboard focuses on respondents beyond the podium
- ensure exports and the on-screen tables show a helpful empty-state message when no post-podium patrols exist
- update the scoreboard grid so multiple categories can sit side by side with consistent spacing on wide displays

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e547b5a02483269c9ea47c95ce0940