### PR TITLE
Combine scoreboard and rules links in hero panel

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -151,7 +151,7 @@ body {
   gap: 14px;
 }
 
-.hero-panel--results {
+.hero-panel--links {
   gap: 12px;
 }
 
@@ -208,11 +208,7 @@ body {
   gap: 16px;
 }
 
-.hero-panel--rules {
-  gap: 16px;
-}
-
-.hero-panel--rules .hero-panel-links {
+.hero-panel--links .hero-panel-links {
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2016,26 +2016,23 @@ function StationApp({
                 lastSyncedAt={lastSavedAt}
               />
             </div>
-            <div className="hero-panel hero-panel--results">
-              <span className="hero-panel-label">Výsledky</span>
-              <a
-                className="hero-panel-link"
-                href={SCOREBOARD_ROUTE_PREFIX}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Otevřít výsledkovou tabuli
-              </a>
-              <span className="hero-panel-sub">Přehled výsledků v novém okně.</span>
-            </div>
             <div className="hero-panel hero-panel--actions">
               <span className="hero-panel-label">Účet</span>
               <button type="button" className="logout-button" onClick={handleLogout}>
                 Odhlásit se
               </button>
             </div>
-            <div className="hero-panel hero-panel--rules">
-              <span className="hero-panel-label">Pravidla</span>
+            <div className="hero-panel hero-panel--links">
+              <span className="hero-panel-label">Odkazy</span>
+              <a
+                className="hero-panel-link"
+                href={SCOREBOARD_ROUTE_PREFIX}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Otevřít výsledky
+              </a>
+              <span className="hero-panel-sub">Přehled výsledků v novém okně.</span>
               <div className="hero-panel-links">
                 <a
                   className="hero-panel-link"


### PR DESCRIPTION
## Summary
- merge the results and rules panels into a single "Odkazy" hero panel
- rename the scoreboard button to "Otevřít výsledky"
- adjust styling to support the unified links layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e552c510988326b48f668f2ef62298