### PR TITLE
Remove redundant scoreboard hint

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2032,7 +2032,6 @@ function StationApp({
               >
                 Otevřít výsledky
               </a>
-              <span className="hero-panel-sub">Přehled výsledků v novém okně.</span>
               <div className="hero-panel-links">
                 <a
                   className="hero-panel-link"


### PR DESCRIPTION
## Summary
- remove the secondary hint text below the scoreboard link in the station app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e554af8be08326a6f28be2aa7af1cb