### PR TITLE
Swap account and links panels in hero header

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2027,12 +2027,6 @@ function StationApp({
                 lastSyncedAt={lastSavedAt}
               />
             </div>
-            <div className="hero-panel hero-panel--actions">
-              <span className="hero-panel-label">Účet</span>
-              <button type="button" className="logout-button" onClick={handleLogout}>
-                Odhlásit se
-              </button>
-            </div>
             <div className="hero-panel hero-panel--links">
               <span className="hero-panel-label">Odkazy</span>
               <a
@@ -2061,6 +2055,12 @@ function StationApp({
                   Pravidla stanovišť
                 </a>
               </div>
+            </div>
+            <div className="hero-panel hero-panel--actions">
+              <span className="hero-panel-label">Účet</span>
+              <button type="button" className="logout-button" onClick={handleLogout}>
+                Odhlásit se
+              </button>
             </div>
           </div>
           {displayAlerts.length ? (


### PR DESCRIPTION
## Summary
- reorder the hero header panels so links are shown before the account controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e642bfa4e48326b4e2ada4e03ad26e