### PR TITLE
Add Severka link to footer

### DIFF
--- a/web/src/components/AppFooter.css
+++ b/web/src/components/AppFooter.css
@@ -58,6 +58,11 @@
   margin: 0;
 }
 
+.app-footer-content a {
+  color: inherit;
+  text-decoration: underline;
+}
+
 .app-footer-logos {
   display: flex;
   gap: clamp(22px, 7vw, 56px);

--- a/web/src/components/AppFooter.tsx
+++ b/web/src/components/AppFooter.tsx
@@ -18,7 +18,13 @@ export default function AppFooter({ className, variant = 'minimal' }: AppFooterP
     <footer className={classes.join(' ')}>
       <div className="app-footer-content">
         <p>© 2025 Zelená liga SPTO · Projekt SPTO Brno · Součást Pionýra</p>
-        <p>Vytvořili 32. PTO Severka a Ševa</p>
+        <p>
+          Vytvořili{' '}
+          <a href="https://severka.org" target="_blank" rel="noreferrer">
+            32. PTO Severka
+          </a>{' '}
+          a Ševa
+        </p>
       </div>
       <div className="app-footer-logos" aria-label="Logo SPTO Brno a Pionýr">
         <a href="https://jihomoravsky.pionyr.cz/pto/" target="_blank" rel="noreferrer" aria-label="SPTO Brno">


### PR DESCRIPTION
## Summary
- add a link to severka.org for the "32. PTO Severka" credit in the shared footer
- ensure footer link inherits existing typography styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e64347f4d88326a762981c86ac9df7