### PR TITLE
Hide scoreboard link for non-target stations

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2029,14 +2029,16 @@ function StationApp({
             </div>
             <div className="hero-panel hero-panel--links">
               <span className="hero-panel-label">Odkazy</span>
-              <a
-                className="hero-panel-link"
-                href={SCOREBOARD_ROUTE_PREFIX}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Otevřít výsledky
-              </a>
+              {isTargetStation ? (
+                <a
+                  className="hero-panel-link"
+                  href={SCOREBOARD_ROUTE_PREFIX}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Otevřít výsledky
+                </a>
+              ) : null}
               <div className="hero-panel-links">
                 <a
                   className="hero-panel-link"

--- a/web/src/auth/LoginScreen.tsx
+++ b/web/src/auth/LoginScreen.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useAuth } from './context';
 import zelenaLigaLogo from '../assets/znak_SPTO_transparent.png';
 import AppFooter from '../components/AppFooter';
-import { SCOREBOARD_ROUTE_PREFIX } from '../routing';
 
 interface Props {
   requirePinOnly?: boolean;
@@ -168,9 +167,6 @@ export default function LoginScreen({ requirePinOnly }: Props) {
               <li>Offline režim se synchronizací výsledků</li>
               <li>Export výsledků do tabulek</li>
             </ul>
-            <a className="auth-hero-link" href={SCOREBOARD_ROUTE_PREFIX}>
-              Zobrazit výsledky Setonova závodu
-            </a>
           </section>
 
           <form


### PR DESCRIPTION
## Summary
- hide the scoreboard link on the station dashboard unless the logged in station is the target station
- remove the scoreboard link from the login page hero panel so non-target stations cannot open it

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e645161bbc8326a51cf0ebc4b70579