### PR TITLE
Remove target answers management from station UI

### DIFF
--- a/web/src/__tests__/stationFlow.test.tsx
+++ b/web/src/__tests__/stationFlow.test.tsx
@@ -580,8 +580,6 @@ describe('station workflow', () => {
     await renderApp();
 
     await waitFor(() => expect(screen.getByText('Načtení hlídek')).toBeInTheDocument());
-    await screen.findByText('Správné odpovědi');
-
     await loadPatrolAndOpenForm(user);
 
     await screen.findAllByText(/Vlci/);
@@ -638,8 +636,6 @@ describe('station workflow', () => {
     await renderApp();
 
     await waitFor(() => expect(screen.getByText('Načtení hlídek')).toBeInTheDocument());
-    await screen.findByText('Správné odpovědi');
-
     await loadPatrolAndOpenForm(user);
 
     await screen.findAllByText(/Vlci/);


### PR DESCRIPTION
## Summary
- remove the "Správné odpovědi" card from the station app so the feature is no longer available in the výpočetka UI
- keep loading of correct answers for automatic scoring logic while removing unused editor state
- update station flow tests to stop expecting the removed UI card

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e6474979648326be84977ca9817053