### PR TITLE
Fix asset base path for subdirectory deployment

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,7 +3,10 @@ import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 import { ROUTE_PREFIX, STATION_ROUTE_PREFIX } from './src/routing';
 
+const BASE_PATH = `${ROUTE_PREFIX}/`;
+
 export default defineConfig({
+  base: BASE_PATH,
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- configure Vite to emit asset URLs under the /setonuv-zavod/ prefix so the app works when served from that subdirectory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e64c4c65b88326a9d2b8c31a064e82