### PR TITLE
Update admin station passages overview with category breakdown

### DIFF
--- a/web/src/admin/AdminApp.css
+++ b/web/src/admin/AdminApp.css
@@ -312,6 +312,29 @@
   font-variant-numeric: tabular-nums;
 }
 
+.admin-table-button {
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.admin-table-button:disabled {
+  cursor: default;
+  color: var(--text-muted);
+}
+
+.admin-table-button--missing {
+  color: var(--py-flame);
+  font-weight: 600;
+}
+
+.admin-table-button--complete {
+  color: var(--text-2);
+}
+
 .admin-station-label {
   display: flex;
   align-items: center;
@@ -330,6 +353,117 @@
   color: var(--zl-green);
   border: 1px solid var(--border);
   font-weight: 700;
+}
+
+.admin-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 1000;
+}
+
+.admin-modal {
+  background: #ffffff;
+  border-radius: 24px;
+  width: min(520px, 100%);
+  max-height: 80vh;
+  overflow: hidden;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+}
+
+.admin-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px 24px 0;
+}
+
+.admin-modal-header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.admin-modal-subtitle {
+  margin: 6px 0 0;
+  font-size: 0.95rem;
+  color: var(--text-2);
+}
+
+.admin-modal-close {
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.admin-modal-close:hover,
+.admin-modal-close:focus-visible {
+  color: var(--text);
+}
+
+.admin-modal-meta {
+  margin: 0;
+  padding: 0 24px;
+  font-size: 0.95rem;
+  color: var(--text-2);
+}
+
+.admin-modal-empty {
+  margin: 0;
+  padding: 12px 24px;
+  color: var(--text-2);
+}
+
+.admin-missing-list {
+  list-style: none;
+  margin: 0;
+  padding: 16px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+}
+
+.admin-missing-list li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface);
+}
+
+.admin-missing-code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: var(--zl-yellow);
+  color: var(--text);
+  font-weight: 700;
+}
+
+.admin-missing-name {
+  color: var(--text-2);
+}
+
+.admin-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 24px 24px;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- display station passage statistics for NH, ND, M and S categories while hiding R entries
- show passed versus total patrol counts per category and overall using patrol totals
- add a modal dialog that lists patrols still missing from a station with supporting styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e65678c0808326a8b7253aef0262ae