### PR TITLE
Improve admin answer summary layout

### DIFF
--- a/web/src/admin/AdminApp.css
+++ b/web/src/admin/AdminApp.css
@@ -270,6 +270,30 @@
   margin: 0;
   font-size: 0.85rem;
   color: var(--text-muted);
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px 0;
+}
+
+.admin-answers-meta-item {
+  display: inline-flex;
+  align-items: center;
+}
+
+.admin-answers-meta-item + .admin-answers-meta-item::before {
+  content: '•';
+  margin-left: 10px;
+  margin-right: 6px;
+  color: currentColor;
+}
+
+.admin-answers-meta-letters {
+  letter-spacing: 0.08em;
+  white-space: normal;
+}
+
+.admin-answers-meta-time {
+  white-space: nowrap;
 }
 
 .admin-table-wrapper {

--- a/web/src/admin/AdminApp.tsx
+++ b/web/src/admin/AdminApp.tsx
@@ -696,6 +696,10 @@ function AdminDashboard({
           <div className="admin-answers-grid">
             {ANSWER_CATEGORIES.map((category) => {
               const summary = answersSummary[category];
+              const hasAnswers = summary.letters.length > 0;
+              const formattedLetters = summary.letters.join(' ');
+              const updatedAt = summary.updatedAt ? new Date(summary.updatedAt) : null;
+
               return (
                 <div key={category} className="admin-answers-field">
                   <label htmlFor={`answers-${category}`}>
@@ -710,10 +714,27 @@ function AdminDashboard({
                     />
                   </label>
                   <p className="admin-answers-meta">
-                    {summary.letters.length
-                      ? `${summary.letters.length} odpovědí • ${summary.letters.join(' ')}`
-                      : 'Nenastaveno'}
-                    {summary.updatedAt ? ` · ${new Date(summary.updatedAt).toLocaleString('cs-CZ')}` : ''}
+                    {hasAnswers ? (
+                      <>
+                        <span className="admin-answers-meta-item admin-answers-meta-count">
+                          {`${summary.letters.length} odpovědí`}
+                        </span>
+                        <span className="admin-answers-meta-item admin-answers-meta-letters">
+                          {formattedLetters}
+                        </span>
+                      </>
+                    ) : (
+                      <span className="admin-answers-meta-item">Nenastaveno</span>
+                    )}
+                    {updatedAt ? (
+                      <time
+                        className="admin-answers-meta-item admin-answers-meta-time"
+                        dateTime={updatedAt.toISOString()}
+                        suppressHydrationWarning
+                      >
+                        {updatedAt.toLocaleString('cs-CZ')}
+                      </time>
+                    ) : null}
                   </p>
                 </div>
               );


### PR DESCRIPTION
## Summary
- keep answer metadata items grouped so separators no longer wrap onto their own lines
- add flex-based styling for the metadata row to wrap gracefully while keeping the timestamp readable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e66604e4548326b6088d3e2dabe5a8