### PR TITLE
Add scoreboard button to admin header

### DIFF
--- a/web/src/admin/AdminApp.tsx
+++ b/web/src/admin/AdminApp.tsx
@@ -15,6 +15,7 @@ import {
   parseAnswerLetters,
 } from '../utils/targetAnswers';
 import { env } from '../envVars';
+import { SCOREBOARD_ROUTE_PREFIX } from '../routing';
 
 const API_BASE_URL = env.VITE_AUTH_API_URL?.replace(/\/$/, '') ?? '';
 
@@ -632,6 +633,14 @@ function AdminDashboard({
             >
               {refreshing ? 'Obnovuji…' : 'Obnovit data'}
             </button>
+            <a
+              className="admin-button admin-button--secondary admin-button--pill"
+              href={SCOREBOARD_ROUTE_PREFIX}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Zobrazit výsledky
+            </a>
             <button
               type="button"
               className="admin-button admin-button--secondary admin-button--pill"


### PR DESCRIPTION
## Summary
- add a new "Zobrazit výsledky" button to the admin header that links to the scoreboard in a new tab

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e66752ffd88326a5a127af8fc26b52