### PR TITLE
Add redesigned admin login page

### DIFF
--- a/web/src/admin/AdminApp.tsx
+++ b/web/src/admin/AdminApp.tsx
@@ -16,6 +16,7 @@ import {
 } from '../utils/targetAnswers';
 import { env } from '../envVars';
 import { SCOREBOARD_ROUTE_PREFIX } from '../routing';
+import AdminLoginScreen from './AdminLoginScreen';
 
 const API_BASE_URL = env.VITE_AUTH_API_URL?.replace(/\/$/, '') ?? '';
 
@@ -962,7 +963,7 @@ function AdminApp() {
   }
 
   if (status.state === 'unauthenticated') {
-    return <LoginScreen />;
+    return <AdminLoginScreen />;
   }
 
   if (status.state === 'password-change-required') {

--- a/web/src/admin/AdminLoginScreen.css
+++ b/web/src/admin/AdminLoginScreen.css
@@ -1,0 +1,322 @@
+.admin-login-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #eaf6ef;
+}
+
+.admin-login-main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+}
+
+.admin-login-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 420px);
+  gap: 32px;
+  width: 100%;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.admin-login-hero {
+  background: linear-gradient(180deg, #57aa27 0%, #4a9722 100%);
+  color: #f7fbf6;
+  padding: 56px;
+  border-radius: 24px;
+  filter: drop-shadow(0 12px 24px rgba(0, 0, 0, 0.08));
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.admin-login-brand {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.admin-login-brand img {
+  height: 64px;
+  width: auto;
+}
+
+.admin-login-brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+}
+
+.admin-login-brand-name {
+  font-weight: 600;
+}
+
+.admin-login-brand-caption {
+  opacity: 0.85;
+}
+
+.admin-login-hero-copy h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 12px;
+}
+
+.admin-login-hero-copy p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.5;
+  opacity: 0.85;
+}
+
+.admin-login-hero-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 1rem;
+}
+
+.admin-login-hero-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.admin-login-hero-list li::before {
+  content: '✅';
+  flex-shrink: 0;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.admin-login-hero-link {
+  color: #f7fbf6;
+  font-size: 0.95rem;
+  text-decoration: underline;
+  align-self: flex-start;
+  transition: opacity 0.2s ease;
+}
+
+.admin-login-hero-link:hover,
+.admin-login-hero-link:focus-visible {
+  opacity: 0.85;
+}
+
+.admin-login-card {
+  background: #ffffff;
+  border: 1px solid #cfe9c5;
+  border-radius: 24px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 420px;
+  width: 100%;
+  color: #333333;
+}
+
+.admin-login-card-header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.admin-login-card-header p {
+  margin: 8px 0 0;
+  color: #555555;
+  line-height: 1.5;
+}
+
+.admin-login-offline {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(255, 216, 79, 0.18);
+  color: #4a9722;
+  font-size: 0.95rem;
+}
+
+.admin-login-offline span[aria-hidden='true'] {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #ffd84f;
+  box-shadow: 0 0 0 4px rgba(255, 216, 79, 0.35);
+}
+
+.admin-login-alert {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(233, 78, 27, 0.1);
+  color: #e94e1b;
+  font-weight: 500;
+}
+
+.admin-login-alert-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #e94e1b;
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.admin-login-field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.admin-login-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: #555555;
+  font-size: 0.95rem;
+}
+
+.admin-login-field span {
+  font-weight: 600;
+  color: #333333;
+}
+
+.admin-login-field input {
+  border: 1px solid #cfe9c5;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: #333333;
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-login-field input::placeholder {
+  color: #999999;
+}
+
+.admin-login-field input:focus-visible {
+  outline: none;
+  border-color: #57aa27;
+  box-shadow: 0 0 0 3px rgba(87, 170, 39, 0.2);
+}
+
+.admin-login-field-error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #e94e1b;
+}
+
+.admin-login-submit {
+  margin-top: 8px;
+  height: 48px;
+  border: none;
+  border-radius: 12px;
+  background: #ffd84f;
+  color: #333333;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.admin-login-submit:hover,
+.admin-login-submit:focus-visible {
+  background: #ffcc33;
+  box-shadow: 0 6px 18px rgba(255, 204, 51, 0.4);
+  outline: none;
+}
+
+.admin-login-submit:disabled {
+  cursor: not-allowed;
+  background: #f0e0a8;
+  box-shadow: none;
+}
+
+.admin-login-links {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.95rem;
+}
+
+.admin-login-link {
+  color: #0055a4;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.admin-login-link:hover,
+.admin-login-link:focus-visible {
+  text-decoration: underline;
+}
+
+.admin-login-footer {
+  padding: 32px;
+}
+
+.admin-login-footer .app-footer-content {
+  text-align: center;
+}
+
+.admin-login-footer .app-footer-logos {
+  justify-content: center;
+}
+
+@media (max-width: 900px) {
+  .admin-login-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-login-hero {
+    min-height: auto;
+  }
+
+  .admin-login-card {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .admin-login-main {
+    padding: 24px;
+  }
+
+  .admin-login-hero {
+    padding: 40px 32px;
+  }
+
+  .admin-login-brand img {
+    height: 48px;
+  }
+
+  .admin-login-card {
+    padding: 28px 24px;
+  }
+
+  .admin-login-submit {
+    width: 100%;
+  }
+}

--- a/web/src/admin/AdminLoginScreen.tsx
+++ b/web/src/admin/AdminLoginScreen.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useState } from 'react';
+import './AdminLoginScreen.css';
+import { useAuth } from '../auth/context';
+import AppFooter from '../components/AppFooter';
+import zelenaLigaLogo from '../assets/znak_SPTO_transparent.png';
+import { translateLoginError, type LoginErrorFeedback } from '../auth/loginErrors';
+import { SCOREBOARD_ROUTE_PREFIX } from '../routing';
+
+export default function AdminLoginScreen() {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [pin, setPin] = useState('');
+  const [error, setError] = useState<LoginErrorFeedback | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [isBrowserOnline, setIsBrowserOnline] = useState(() =>
+    typeof navigator !== 'undefined' ? navigator.onLine : true,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const handleOnline = () => setIsBrowserOnline(true);
+    const handleOffline = () => setIsBrowserOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  const hasEmail = email.trim().length > 0;
+  const hasPassword = password.length > 0;
+  const submitDisabled = loading || !hasEmail || !hasPassword;
+
+  const emailFieldId = 'admin-login-email';
+  const passwordFieldId = 'admin-login-password';
+  const pinFieldId = 'admin-login-pin';
+
+  const emailError = error?.field === 'email' ? error.message : null;
+  const passwordError = error?.field === 'password' ? error.message : null;
+  const pinError = error?.field === 'pin' ? error.message : null;
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!hasEmail || !hasPassword) {
+      return;
+    }
+
+    const trimmedEmail = email.trim();
+    const trimmedPin = pin.trim();
+
+    setError(null);
+    setLoading(true);
+    try {
+      await login({
+        email: trimmedEmail,
+        password,
+        pin: trimmedPin ? trimmedPin : undefined,
+      });
+    } catch (err) {
+      setError(translateLoginError(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="admin-login-page">
+      <main className="admin-login-main">
+        <div className="admin-login-layout">
+          <section className="admin-login-hero" aria-label="Administrace závodu">
+            <div className="admin-login-brand">
+              <img src={zelenaLigaLogo} alt="Logo SPTO Brno" />
+              <div className="admin-login-brand-text">
+                <span className="admin-login-brand-name">SPTO Brno</span>
+                <span className="admin-login-brand-caption">Součást Pionýra</span>
+              </div>
+            </div>
+            <div className="admin-login-hero-copy">
+              <h1>Administrace závodu</h1>
+              <p>Správa závodu, stanovišť a výsledků.</p>
+            </div>
+            <ul className="admin-login-hero-list">
+              <li>Správa závodních dat</li>
+              <li>Export výsledků</li>
+              <li>Přehled a kontrola stanovišť</li>
+            </ul>
+            <a
+              className="admin-login-hero-link"
+              href={SCOREBOARD_ROUTE_PREFIX}
+            >
+              Zobrazit výsledky Setonova závodu
+            </a>
+          </section>
+
+          <form className="admin-login-card" onSubmit={handleSubmit} noValidate>
+            <header className="admin-login-card-header">
+              <h2>Přihlášení administrátora</h2>
+              <p>Údaje získáš od hlavního správce závodu.</p>
+            </header>
+
+            {!isBrowserOnline ? (
+              <div className="admin-login-offline" role="status">
+                <span aria-hidden="true" />
+                Připojení je offline. Pokus se znovu po obnovení.
+              </div>
+            ) : null}
+
+            {error ? (
+              <div className="admin-login-alert" role="alert">
+                <span className="admin-login-alert-icon" aria-hidden="true">
+                  !
+                </span>
+                <span>{error.message}</span>
+              </div>
+            ) : null}
+
+            <div className="admin-login-field-group">
+              <label className="admin-login-field" htmlFor={emailFieldId}>
+                <span>E-mail</span>
+                <input
+                  id={emailFieldId}
+                  type="email"
+                  inputMode="email"
+                  autoComplete="username"
+                  value={email}
+                  onChange={(event) => {
+                    setEmail(event.target.value);
+                    setError((current) => (current && current.field === 'email' ? null : current));
+                  }}
+                  placeholder="jan.novak@…"
+                  required
+                  aria-invalid={emailError ? 'true' : 'false'}
+                  aria-describedby={emailError ? `${emailFieldId}-error` : undefined}
+                />
+              </label>
+              {emailError ? (
+                <p id={`${emailFieldId}-error`} className="admin-login-field-error">
+                  {emailError}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="admin-login-field-group">
+              <label className="admin-login-field" htmlFor={passwordFieldId}>
+                <span>Heslo</span>
+                <input
+                  id={passwordFieldId}
+                  type="password"
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(event) => {
+                    setPassword(event.target.value);
+                    setError((current) => (current && current.field === 'password' ? null : current));
+                  }}
+                  placeholder="••••••••"
+                  required
+                  aria-invalid={passwordError ? 'true' : 'false'}
+                  aria-describedby={passwordError ? `${passwordFieldId}-error` : undefined}
+                />
+              </label>
+              {passwordError ? (
+                <p id={`${passwordFieldId}-error`} className="admin-login-field-error">
+                  {passwordError}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="admin-login-field-group">
+              <label className="admin-login-field" htmlFor={pinFieldId}>
+                <span>PIN / Zařízení (volitelné)</span>
+                <input
+                  id={pinFieldId}
+                  type="password"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  maxLength={6}
+                  value={pin}
+                  onChange={(event) => {
+                    const raw = event.target.value.replace(/[^0-9]/g, '');
+                    setPin(raw);
+                    setError((current) => (current && current.field === 'pin' ? null : current));
+                  }}
+                  placeholder="např. 1234"
+                  aria-invalid={pinError ? 'true' : 'false'}
+                  aria-describedby={pinError ? `${pinFieldId}-error` : undefined}
+                />
+              </label>
+              {pinError ? (
+                <p id={`${pinFieldId}-error`} className="admin-login-field-error">
+                  {pinError}
+                </p>
+              ) : null}
+            </div>
+
+            <button type="submit" disabled={submitDisabled} className="admin-login-submit">
+              {loading ? 'Přihlašuji…' : 'Přihlásit se'}
+            </button>
+
+            <div className="admin-login-links">
+              <a className="admin-login-link" href="mailto:zavody@zelenaliga.cz">
+                Zapomenuté heslo
+              </a>
+              <a className="admin-login-link" href="/">
+                Zpět na Zelenou ligu
+              </a>
+            </div>
+          </form>
+        </div>
+      </main>
+      <AppFooter className="admin-login-footer" />
+    </div>
+  );
+}

--- a/web/src/auth/LoginScreen.tsx
+++ b/web/src/auth/LoginScreen.tsx
@@ -3,63 +3,10 @@ import { useAuth } from './context';
 import zelenaLigaLogo from '../assets/znak_SPTO_transparent.png';
 import AppFooter from '../components/AppFooter';
 import { ADMIN_ROUTE_PREFIX } from '../routing';
+import { translateLoginError, type LoginErrorFeedback } from './loginErrors';
 
 interface Props {
   requirePinOnly?: boolean;
-}
-
-type LoginErrorField = 'email' | 'password' | 'pin';
-
-interface LoginErrorFeedback {
-  message: string;
-  field?: LoginErrorField;
-}
-
-function translateLoginError(error: unknown) {
-  const message = (error instanceof Error ? error.message : String(error)).trim();
-  const fallback: LoginErrorFeedback = {
-    message: 'Nelze ověřit přihlášení. Zkontroluj připojení.',
-  };
-
-  if (!message) {
-    return fallback;
-  }
-
-  const normalized = message.toLowerCase();
-
-  if (normalized.includes('invalid credentials')) {
-    return { message: 'Zadané údaje nejsou správné.', field: 'password' };
-  }
-
-  if (normalized.includes('invalid login response')) {
-    return fallback;
-  }
-
-  if (normalized.includes('missing session identifier')) {
-    return fallback;
-  }
-
-  if (normalized.includes('failed to fetch') || normalized.includes('request failed')) {
-    return fallback;
-  }
-
-  if (normalized.includes('pin required')) {
-    return { message: 'Zadané údaje nejsou správné.', field: 'pin' };
-  }
-
-  if (normalized.includes('invalid pin')) {
-    return { message: 'Zadané údaje nejsou správné.', field: 'pin' };
-  }
-
-  if (normalized.includes('invalid token')) {
-    return fallback;
-  }
-
-  if (normalized.includes('locked') || normalized.includes('suspended') || normalized.includes('blocked')) {
-    return { message: 'Účet je dočasně zablokován. Zkuste to za 15 minut.', field: 'password' };
-  }
-
-  return fallback;
 }
 
 export default function LoginScreen({ requirePinOnly }: Props) {

--- a/web/src/auth/loginErrors.ts
+++ b/web/src/auth/loginErrors.ts
@@ -1,0 +1,53 @@
+export type LoginErrorField = 'email' | 'password' | 'pin';
+
+export interface LoginErrorFeedback {
+  message: string;
+  field?: LoginErrorField;
+}
+
+export function translateLoginError(error: unknown): LoginErrorFeedback {
+  const message = (error instanceof Error ? error.message : String(error)).trim();
+  const fallback: LoginErrorFeedback = {
+    message: 'Nelze ověřit přihlášení. Zkontroluj připojení.',
+  };
+
+  if (!message) {
+    return fallback;
+  }
+
+  const normalized = message.toLowerCase();
+
+  if (normalized.includes('invalid credentials')) {
+    return { message: 'Zadané údaje nejsou správné.', field: 'password' };
+  }
+
+  if (normalized.includes('invalid login response')) {
+    return fallback;
+  }
+
+  if (normalized.includes('missing session identifier')) {
+    return fallback;
+  }
+
+  if (normalized.includes('failed to fetch') || normalized.includes('request failed')) {
+    return fallback;
+  }
+
+  if (normalized.includes('pin required')) {
+    return { message: 'Zadané údaje nejsou správné.', field: 'pin' };
+  }
+
+  if (normalized.includes('invalid pin')) {
+    return { message: 'Zadané údaje nejsou správné.', field: 'pin' };
+  }
+
+  if (normalized.includes('invalid token')) {
+    return fallback;
+  }
+
+  if (normalized.includes('locked') || normalized.includes('suspended') || normalized.includes('blocked')) {
+    return { message: 'Účet je dočasně zablokován. Zkuste to za 15 minut.', field: 'password' };
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- add a dedicated admin login screen with the new hero and form layout for administrators
- extract shared login error translation logic for reuse across login experiences

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e678e38a4c8326975df7036766a846