### PR TITLE
Adjust referee login layout and admin button styling

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1752,9 +1752,9 @@ textarea {
   height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: clamp(40px, 6vw, 48px) clamp(24px, 5vw, 40px);
-  border-radius: 24px;
+  gap: 20px;
+  padding: clamp(32px, 5vw, 40px) clamp(20px, 4vw, 32px);
+  border-radius: 20px;
   background: linear-gradient(180deg, var(--zl-green) 0%, var(--zl-green-dark) 100%);
   color: #ffffff;
 }
@@ -1838,22 +1838,29 @@ textarea {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-top: 12px;
-  padding: 12px 20px;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 10px 18px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  background: rgba(255, 255, 255, 0.12);
-  color: #ffffff;
+  border: 1px solid rgba(236, 179, 8, 0.4);
+  background: linear-gradient(180deg, #fef3c7 0%, #facc15 100%);
+  color: #3b2f0b;
   text-decoration: none;
   font-weight: 600;
   letter-spacing: 0.01em;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 6px 16px rgba(250, 204, 21, 0.32);
 }
 
 .auth-hero-admin-button:hover,
 .auth-hero-admin-button:focus-visible {
-  background: rgba(255, 255, 255, 0.2);
-  border-color: rgba(255, 255, 255, 0.6);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(250, 204, 21, 0.35);
+}
+
+.auth-hero-admin-icon {
+  font-size: 1rem;
+  line-height: 1;
 }
 
 .auth-hero-secondary {
@@ -1880,12 +1887,12 @@ textarea {
 .auth-card {
   background: #ffffff;
   border: 1px solid var(--border);
-  border-radius: 24px;
-  padding: clamp(24px, 4vw, 32px);
+  border-radius: 20px;
+  padding: clamp(20px, 4vw, 28px);
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 18px;
 }
 
 .auth-card h1,

--- a/web/src/auth/LoginScreen.tsx
+++ b/web/src/auth/LoginScreen.tsx
@@ -121,7 +121,10 @@ export default function LoginScreen({ requirePinOnly }: Props) {
               target="_blank"
               rel="noreferrer"
             >
-              Přihlášení pro kancelář závodu
+              <span>Přihlášení pro kancelář závodu</span>
+              <span className="auth-hero-admin-icon" aria-hidden="true">
+                ↗
+              </span>
             </a>
           </section>
 


### PR DESCRIPTION
## Summary
- reduce padding and radius on the referee hero and form cards to make them more compact
- restyle the admin login button with yellow gradient styling and an arrow icon to match the new design

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e67db007f883268a2ffc46262164d8