### PR TITLE
Update admin station overview to hide unsupported categories

### DIFF
--- a/web/src/admin/AdminApp.css
+++ b/web/src/admin/AdminApp.css
@@ -371,6 +371,11 @@
   font-variant-numeric: tabular-nums;
 }
 
+.admin-table td:nth-child(2),
+.admin-table th:nth-child(2) {
+  text-align: left;
+}
+
 .admin-table-button {
   border: none;
   background: none;
@@ -392,6 +397,17 @@
 
 .admin-table-button--complete {
   color: var(--text-2);
+}
+
+.admin-station-categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  justify-content: flex-start;
+}
+
+.admin-station-categories .admin-table-button {
+  min-width: 72px;
 }
 
 .admin-station-label {


### PR DESCRIPTION
## Summary
- map each station to the categories it should handle on the admin overview
- adjust statistics calculations to only include allowed categories per station
- refresh the table layout and modal messaging to display the filtered counts clearly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e68156c2a083269f1207f504291b21