### PR TITLE
Align admin station summary table columns

### DIFF
--- a/web/src/admin/AdminApp.css
+++ b/web/src/admin/AdminApp.css
@@ -365,14 +365,14 @@
   box-shadow: inset 0 0 0 1px rgba(87, 170, 39, 0.08);
 }
 
-.admin-table td:not(:first-child),
-.admin-table th:not(:first-child) {
+.admin-table td,
+.admin-table th {
   text-align: center;
   font-variant-numeric: tabular-nums;
 }
 
-.admin-table td:nth-child(2),
-.admin-table th:nth-child(2) {
+.admin-table td:first-child,
+.admin-table th:first-child {
   text-align: left;
 }
 
@@ -383,10 +383,22 @@
   font: inherit;
   color: inherit;
   cursor: pointer;
+  min-width: 72px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .admin-table-button:disabled {
   cursor: default;
+  color: var(--text-muted);
+}
+
+.admin-table-placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
   color: var(--text-muted);
 }
 
@@ -397,17 +409,6 @@
 
 .admin-table-button--complete {
   color: var(--text-2);
-}
-
-.admin-station-categories {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 16px;
-  justify-content: flex-start;
-}
-
-.admin-station-categories .admin-table-button {
-  min-width: 72px;
 }
 
 .admin-station-label {

--- a/web/src/admin/AdminApp.tsx
+++ b/web/src/admin/AdminApp.tsx
@@ -829,8 +829,10 @@ function AdminDashboard({
                 <thead>
                   <tr>
                     <th>Stanoviště</th>
-                    <th>Kategorie</th>
-                    <th>Celkem</th>
+                    {STATION_PASSAGE_CATEGORIES.map((category) => (
+                      <th key={category}>{category}</th>
+                    ))}
+                    <th>CELKEM</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -842,40 +844,47 @@ function AdminDashboard({
                           <span>{row.stationName}</span>
                         </div>
                       </td>
-                      <td>
-                        <div className="admin-station-categories">
-                          {row.categories.map((category) => {
-                            const expectedInCategory = row.expectedTotals[category];
-                            const passed = row.totals[category];
-                            const missingCount = row.missing[category].length;
-                            const isDisabled = expectedInCategory === 0 && passed === 0;
-                            const ariaLabel =
-                              `Stanoviště ${row.stationCode} ${row.stationName}` +
-                              ` – kategorie ${category}: ${passed} z ${expectedInCategory}`;
-                            const buttonClassNames = [
-                              'admin-table-button',
-                              missingCount > 0
-                                ? 'admin-table-button--missing'
-                                : 'admin-table-button--complete',
-                            ]
-                              .filter(Boolean)
-                              .join(' ');
+                      {STATION_PASSAGE_CATEGORIES.map((category) => {
+                        const isAllowed = row.categories.includes(category);
 
-                            return (
-                              <button
-                                key={`${row.stationId}-${category}`}
-                                type="button"
-                                className={buttonClassNames}
-                                onClick={() => handleOpenStationMissing(row, category)}
-                                disabled={isDisabled}
-                                aria-label={ariaLabel}
-                              >
-                                {passed}/{expectedInCategory}
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </td>
+                        if (!isAllowed) {
+                          return (
+                            <td key={`${row.stationId}-${category}`}>
+                              <span className="admin-table-placeholder">–</span>
+                            </td>
+                          );
+                        }
+
+                        const expectedInCategory = row.expectedTotals[category];
+                        const passed = row.totals[category];
+                        const missingCount = row.missing[category].length;
+                        const isDisabled = expectedInCategory === 0 && passed === 0;
+                        const ariaLabel =
+                          `Stanoviště ${row.stationCode} ${row.stationName}` +
+                          ` – kategorie ${category}: ${passed} z ${expectedInCategory}`;
+                        const buttonClassNames = [
+                          'admin-table-button',
+                          missingCount > 0
+                            ? 'admin-table-button--missing'
+                            : 'admin-table-button--complete',
+                        ]
+                          .filter(Boolean)
+                          .join(' ');
+
+                        return (
+                          <td key={`${row.stationId}-${category}`}>
+                            <button
+                              type="button"
+                              className={buttonClassNames}
+                              onClick={() => handleOpenStationMissing(row, category)}
+                              disabled={isDisabled}
+                              aria-label={ariaLabel}
+                            >
+                              {passed}/{expectedInCategory}
+                            </button>
+                          </td>
+                        );
+                      })}
                       <td>
                         <button
                           type="button"


### PR DESCRIPTION
## Summary
- render station passage overview with fixed columns for each category in NH→RD order
- show placeholders for unavailable categories while keeping total column and actions intact
- adjust table styling for new layout and consistent button sizing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6870df1a483269769336d321a8767