### PR TITLE
Adjust login page visuals and remove admin results link

### DIFF
--- a/web/src/admin/AdminApp.tsx
+++ b/web/src/admin/AdminApp.tsx
@@ -15,7 +15,6 @@ import {
   parseAnswerLetters,
 } from '../utils/targetAnswers';
 import { env } from '../envVars';
-import { SCOREBOARD_ROUTE_PREFIX } from '../routing';
 import AdminLoginScreen from './AdminLoginScreen';
 
 const API_BASE_URL = env.VITE_AUTH_API_URL?.replace(/\/$/, '') ?? '';
@@ -676,14 +675,6 @@ function AdminDashboard({
             >
               {refreshing ? 'Obnovuji…' : 'Obnovit data'}
             </button>
-            <a
-              className="admin-button admin-button--secondary admin-button--pill"
-              href={SCOREBOARD_ROUTE_PREFIX}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Zobrazit výsledky
-            </a>
             <button
               type="button"
               className="admin-button admin-button--secondary admin-button--pill"

--- a/web/src/admin/AdminLoginScreen.tsx
+++ b/web/src/admin/AdminLoginScreen.tsx
@@ -4,7 +4,6 @@ import { useAuth } from '../auth/context';
 import AppFooter from '../components/AppFooter';
 import zelenaLigaLogo from '../assets/znak_SPTO_transparent.png';
 import { translateLoginError, type LoginErrorFeedback } from '../auth/loginErrors';
-import { SCOREBOARD_ROUTE_PREFIX } from '../routing';
 
 export default function AdminLoginScreen() {
   const { login } = useAuth();
@@ -89,19 +88,10 @@ export default function AdminLoginScreen() {
             <ul className="login-hero-list">
               {heroItems.map((item) => (
                 <li key={item} className="login-hero-list-item">
-                  <span className="login-hero-list-icon" aria-hidden="true">
-                    ✅
-                  </span>
-                  <span>{item}</span>
+                  {item}
                 </li>
               ))}
             </ul>
-            <a className="login-hero-button" href={SCOREBOARD_ROUTE_PREFIX}>
-              <span>Zobrazit výsledky Setonova závodu</span>
-              <span className="login-hero-button-icon" aria-hidden="true">
-                →
-              </span>
-            </a>
           </section>
 
           <form className="login-card" onSubmit={handleSubmit} noValidate>

--- a/web/src/auth/LoginScreen.tsx
+++ b/web/src/auth/LoginScreen.tsx
@@ -121,10 +121,7 @@ export default function LoginScreen({ requirePinOnly }: Props) {
             <ul className="login-hero-list">
               {heroItems.map((item) => (
                 <li key={item} className="login-hero-list-item">
-                  <span className="login-hero-list-icon" aria-hidden="true">
-                    ✅
-                  </span>
-                  <span>{item}</span>
+                  {item}
                 </li>
               ))}
             </ul>

--- a/web/src/styles/LoginPage.css
+++ b/web/src/styles/LoginPage.css
@@ -41,9 +41,11 @@
 }
 
 .login-hero-logo {
-  width: 64px;
-  height: 64px;
+  width: 72px;
+  max-height: 72px;
+  height: auto;
   display: block;
+  object-fit: contain;
 }
 
 .login-hero-brand-text {
@@ -96,34 +98,17 @@
 
 .login-hero-list {
   margin: 0;
-  padding: 0;
-  list-style: none;
+  padding: 0 0 0 24px;
+  list-style: disc;
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
 .login-hero-list-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
   font-size: 1rem;
   line-height: 1.6;
   color: rgba(255, 255, 255, 0.92);
-}
-
-.login-hero-list-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  font-size: 1.05rem;
-  line-height: 1;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.18);
-  color: #ffffff;
-  margin-top: 2px;
 }
 
 .login-hero-button {


### PR DESCRIPTION
## Summary
- ensure the login logo keeps its aspect ratio and swap the hero list to use standard bullets instead of emoji icons
- drop the "Zobrazit výsledky" button from the admin login hero and the signed-in admin header actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e78039520483268965791fe22bd159