### PR TITLE
Adjust hero links label for standard stations

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1926,7 +1926,7 @@ function StationApp({
               />
             </div>
             <div className="hero-panel hero-panel--links">
-              <span className="hero-panel-label">Odkazy</span>
+              <span className="hero-panel-label">{stationCode === 'T' ? 'Odkazy' : 'Pravidla'}</span>
               {showScoreboardLink ? (
                 <a
                   className="hero-panel-link"


### PR DESCRIPTION
## Summary
- update the station hero panel label to read "Pravidla" unless the station is the calculation post, which remains "Odkazy"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e78d2dae2883268f6b6c90aed3f1d7