### PR TITLE
Add toggle to hide completed tickets in queue

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1111,22 +1111,6 @@ function StationApp({
     [initializeFormForPatrol, patrolById, pushAlert, tickets, updateTickets],
   );
 
-  const handleResetTickets = useCallback(() => {
-    let removedTickets = 0;
-    updateTickets((current) =>
-      current.filter((ticket) => {
-        const keep = ticket.state !== 'done';
-        if (!keep) {
-          removedTickets += 1;
-        }
-        return keep;
-      }),
-    );
-    if (removedTickets > 0) {
-      pushAlert('Dokončené hlídky byly odebrány z fronty.');
-    }
-  }, [pushAlert, updateTickets]);
-
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const desiredPath = getStationPath(stationDisplayName);
@@ -2083,7 +2067,6 @@ function StationApp({
               tickets={tickets}
               heartbeat={tick}
               onChangeState={handleTicketStateChange}
-              onReset={handleResetTickets}
             />
           ) : null}
 


### PR DESCRIPTION
## Summary
- replace the "Odebrat dokončené hlídky" action with a toggle that hides or shows completed tickets in the queue
- drop the unused reset handler in the station app now that completed tickets are only hidden client-side

## Testing
- npm run test -- --run tests

------
https://chatgpt.com/codex/tasks/task_e_68e78cfad1908326a904a6b04225e295