### PR TITLE
Remove manual entry helper text from station view

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2365,11 +2365,7 @@ function StationApp({
                     <span className="scanner-note">Hlídka už čeká ve frontě.</span>
                   ) : null}
                 </div>
-              ) : (
-                <p className="scanner-placeholder">
-                  Zadej kód hlídky ručně.
-                </p>
-              )}
+              ) : null}
             </div>
           </section>
 

--- a/web/src/__tests__/stationFlow.test.tsx
+++ b/web/src/__tests__/stationFlow.test.tsx
@@ -529,9 +529,11 @@ describe('station workflow', () => {
     const loadButton = screen.getByRole('button', { name: 'Načíst hlídku' });
     expect(loadButton).toBeDisabled();
 
-    expect(
-      await screen.findByText('Vyber kategorii, pohlaví a číslo hlídky.'),
-    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Vyber kategorii, pohlaví a číslo hlídky.'),
+      ).not.toBeInTheDocument(),
+    );
 
     expect(screen.queryByRole('button', { name: 'Obsluhovat' })).not.toBeInTheDocument();
   });

--- a/web/src/components/PatrolCodeInput.tsx
+++ b/web/src/components/PatrolCodeInput.tsx
@@ -359,7 +359,7 @@ export default function PatrolCodeInput({
         code: canonical,
         valid: false,
         reason: 'incomplete',
-        message: 'Vyber kategorii, pohlaví a číslo hlídky.',
+        message: '',
       };
     }
     if (!PATROL_CODE_REGEX.test(canonical)) {
@@ -491,13 +491,15 @@ export default function PatrolCodeInput({
       <div className="patrol-code-input__value" aria-live="polite">
         {displayValue}
       </div>
-      <small
-        id={feedbackId}
-        className={validationState.valid ? 'valid' : 'invalid'}
-        aria-live="polite"
-      >
-        {validationState.message}
-      </small>
+      {validationState.message ? (
+        <small
+          id={feedbackId}
+          className={validationState.valid ? 'valid' : 'invalid'}
+          aria-live="polite"
+        >
+          {validationState.message}
+        </small>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- hide the incomplete patrol selection warning until there is a real validation error
- remove the empty state helper text beneath the manual patrol entry panel
- update the station workflow test to reflect the new copyless design

## Testing
- npm test -- stationFlow.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e79c68ac4c832685bdce8967280713