### PR TITLE
Filter patrol picker to pending visitors

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2306,6 +2306,7 @@ function StationApp({
                   label="Ruční kód"
                   registry={patrolRegistryState}
                   onValidationChange={setManualValidation}
+                  excludePatrolIds={stationPassageVisitedSet}
                 />
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- hide patrol codes that have already passed the station from the manual entry wheel
- pass the station's visited patrol ids to the manual entry picker so only remaining numbers are listed

## Testing
- npm test -- --run src/__tests__/stationFlow.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e79dca2a04832683265798c91cdf64