### PR TITLE
Remove target answers report from station interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Server poskytuje endpointy:
   automatickými pokusy o synchronizaci a ručním přehledem.
 - Přehled posledních výsledků s napojením na Supabase Realtime, detailní
   náhled terčových odpovědí a rychlé opravy bodů ostatních stanovišť.
-- Report terčových odpovědí s exportem do CSV a historie skenování pro audit.
 - Samostatný výsledkový přehled (scoreboard) pro kancelář s automatickým
   obnovováním a exportem do XLSX.
 

--- a/docs/USER_GUIDE.cs.md
+++ b/docs/USER_GUIDE.cs.md
@@ -72,8 +72,6 @@ praktický návod pro provoz na stanovišti i pro kancelář závodu.
      a uložit přímo do Supabase.
    - *Poslední výsledky* načítají streamovaná data ze Supabase – vhodné pro
      rychlou kontrolu, zda se záznam skutečně propsal.
-   - Stanoviště „T“ má navíc *Report terčových odpovědí* s filtrem podle hlídek a
-     exportem do CSV.
 
 ## 4. Offline režim
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import localforage from 'localforage';
 // import QRScanner from './components/QRScanner';
 import LastScoresList from './components/LastScoresList';
-import TargetAnswersReport from './components/TargetAnswersReport';
 import PatrolCodeInput, {
   normalisePatrolCode,
   PatrolRegistryEntry,
@@ -2932,14 +2931,6 @@ function StationApp({
           </section>
 
           <LastScoresList eventId={eventId} stationId={stationId} isTargetStation={isTargetStation} />
-          {isTargetStation ? (
-            <TargetAnswersReport
-              eventId={eventId}
-              stationId={stationId}
-              stationName={stationDisplayName}
-              stationCode={stationCode}
-            />
-          ) : null}
         </>
       </main>
       <AppFooter />

--- a/web/src/__tests__/stationFlow.test.tsx
+++ b/web/src/__tests__/stationFlow.test.tsx
@@ -503,6 +503,8 @@ describe('station workflow', () => {
     expect(await screen.findByText(/Záznam uložen do fronty/)).toBeInTheDocument();
     expect(await screen.findByText(/Čeká na odeslání: 1/)).toBeInTheDocument();
 
+    await user.click(screen.getByRole('button', { name: 'Zobrazit frontu' }));
+
     const queueLabel = await screen.findByText('Vlci (N-01)');
     expect(queueLabel).toBeInTheDocument();
     expect(screen.getByText('Manuální body')).toBeInTheDocument();
@@ -743,6 +745,7 @@ describe('station workflow', () => {
     await user.click(screen.getByRole('button', { name: 'Uložit záznam' }));
 
     expect(await screen.findByText(/Čeká na odeslání: 1/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Zobrazit frontu' }));
     expect(await screen.findByText(/Chyba: Session revoked/)).toBeInTheDocument();
     expect(await screen.findByText('Přihlášení vypršelo, přihlas se prosím znovu.')).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- remove the target answers report card from the station application UI
- update README and the Czech user guide so they no longer reference the report
- adjust station workflow tests to open the offline queue details when asserting queued items

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e7aa5d85c883268ed34a380203f663