### PR TITLE
Fix auth API imports for Node resolution

### DIFF
--- a/web/api/auth/change-password.ts
+++ b/web/api/auth/change-password.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
-import { hashPassword } from './password-utils';
+import { hashPassword } from './password-utils.js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;

--- a/web/api/auth/reset-password.ts
+++ b/web/api/auth/reset-password.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
-import { hashPassword, generateTemporaryPassword } from './password-utils';
+import { hashPassword, generateTemporaryPassword } from './password-utils.js';
 
 const REQUIRED_ENV_VARS = ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'RESEND_API_KEY'];
 


### PR DESCRIPTION
## Summary
- update auth API routes to import the shared password utilities with explicit .js extensions so Node's ESM loader can resolve them

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eb8a315dd88326850217c7e0638969