### PR TITLE
Update forgot password page styling

### DIFF
--- a/web/src/auth/ForgotPasswordScreen.tsx
+++ b/web/src/auth/ForgotPasswordScreen.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useCallback, useState } from 'react';
 import '../styles/LoginPage.css';
 import '../styles/ForgotPasswordPage.css';
 import AppFooter from '../components/AppFooter';
@@ -40,6 +40,10 @@ export default function ForgotPasswordScreen() {
   const showSuccess = feedback === 'success';
   const showError = feedback === 'error';
 
+  const handleBackToLogin = useCallback(() => {
+    window.location.assign(ROUTE_PREFIX);
+  }, []);
+
   return (
     <div className="login-page login-page--forgot">
       <main className="login-main">
@@ -61,9 +65,9 @@ export default function ForgotPasswordScreen() {
               <li className="login-hero-list-item">Odkaz platný 15 minut</li>
               <li className="login-hero-list-item">Správa účtu v Zelené lize</li>
             </ul>
-            <a className="login-hero-back" href={ROUTE_PREFIX}>
+            <button type="button" className="login-hero-back-button" onClick={handleBackToLogin}>
               ← Zpět na přihlášení
-            </a>
+            </button>
           </section>
 
           <form className="login-card login-form" onSubmit={handleSubmit} noValidate>
@@ -122,9 +126,13 @@ export default function ForgotPasswordScreen() {
             </button>
 
             <div className="login-form-footer">
-              <a className="login-link" href={ROUTE_PREFIX}>
+              <button
+                type="button"
+                className="login-form-back-button"
+                onClick={handleBackToLogin}
+              >
                 ← Zpět na přihlášení
-              </a>
+              </button>
             </div>
           </form>
         </div>

--- a/web/src/styles/ForgotPasswordPage.css
+++ b/web/src/styles/ForgotPasswordPage.css
@@ -71,9 +71,9 @@
 }
 
 .login-hero-list--checks {
-  list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 0 0 24px;
+  list-style: disc;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -81,43 +81,37 @@
 }
 
 .login-hero-list--checks .login-hero-list-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
   font-size: 1rem;
   line-height: 1.5;
   color: rgba(255, 255, 255, 0.92);
 }
 
-.login-hero-list--checks .login-hero-list-item::before {
-  content: '';
-  flex-shrink: 0;
-  display: inline-block;
-  width: 18px;
-  height: 18px;
-  border: 3px solid rgba(255, 255, 255, 0.9);
-  border-top: 0;
-  border-left: 0;
-  transform: rotate(45deg);
-  border-radius: 2px;
-  margin-top: 2px;
-}
-
-.login-hero-back {
+.login-hero-back-button {
+  align-self: flex-start;
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  color: rgba(255, 255, 255, 0.9);
-  text-decoration: none;
-  font-weight: 500;
-  transition: opacity 0.2s ease, text-decoration-color 0.2s ease;
+  padding: 12px 22px;
+  border-radius: 999px;
+  border: 2px solid rgba(255, 255, 255, 0.75);
+  background: transparent;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
-.login-hero-back:hover,
-.login-hero-back:focus-visible {
-  opacity: 1;
-  text-decoration: underline;
+.login-hero-back-button:hover,
+.login-hero-back-button:focus-visible {
+  background: rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+  transform: translateY(-1px);
   outline: none;
+}
+
+.login-hero-back-button:focus-visible {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.4);
 }
 
 .login-page--forgot .login-card {
@@ -183,6 +177,33 @@
   display: flex;
   justify-content: flex-start;
   margin-top: 8px;
+}
+
+.login-form-back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid #dfe5db;
+  background: transparent;
+  color: #2b2b2b;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.login-form-back-button:hover,
+.login-form-back-button:focus-visible {
+  background: rgba(87, 170, 39, 0.1);
+  border-color: rgba(87, 170, 39, 0.35);
+  color: #2b2b2b;
+  outline: none;
+}
+
+.login-form-back-button:focus-visible {
+  box-shadow: 0 0 0 3px rgba(87, 170, 39, 0.25);
 }
 
 .login-feedback {


### PR DESCRIPTION
## Summary
- replace the forgot password checklist styling with standard bullet points
- add dedicated buttons to return to the login screen in both the hero and form footer
- style the new buttons to match the forgot password layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eb918569148326a280db948ef80ca7