### PR TITLE
Fix admin forgot password link

### DIFF
--- a/web/src/admin/AdminLoginScreen.tsx
+++ b/web/src/admin/AdminLoginScreen.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../auth/context';
 import AppFooter from '../components/AppFooter';
 import zelenaLigaLogo from '../assets/znak_SPTO_transparent.png';
 import { translateLoginError, type LoginErrorFeedback } from '../auth/loginErrors';
+import { FORGOT_PASSWORD_ROUTE } from '../routing';
 
 export default function AdminLoginScreen() {
   const { login } = useAuth();
@@ -197,7 +198,7 @@ export default function AdminLoginScreen() {
             </button>
 
             <div className="login-links">
-              <a className="login-link" href="mailto:zavody@zelenaliga.cz">
+              <a className="login-link" href={FORGOT_PASSWORD_ROUTE}>
                 Zapomenuté heslo
               </a>
               <a className="login-link login-link--muted" href="/">


### PR DESCRIPTION
## Summary
- route the admin "Zapomenuté heslo" link to the password reset page instead of email

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb91ca86248326999b203c37740420