### PR TITLE
Style forgot password back button like hero CTA

### DIFF
--- a/web/src/auth/ForgotPasswordScreen.tsx
+++ b/web/src/auth/ForgotPasswordScreen.tsx
@@ -66,7 +66,10 @@ export default function ForgotPasswordScreen() {
               <li className="login-hero-list-item">Správa účtu v Zelené lize</li>
             </ul>
             <button type="button" className="login-hero-back-button" onClick={handleBackToLogin}>
-              ← Zpět na přihlášení
+              <span>Zpět na přihlášení</span>
+              <span className="login-back-button-icon" aria-hidden="true">
+                →
+              </span>
             </button>
           </section>
 
@@ -131,7 +134,10 @@ export default function ForgotPasswordScreen() {
                 className="login-form-back-button"
                 onClick={handleBackToLogin}
               >
-                ← Zpět na přihlášení
+                <span>Zpět na přihlášení</span>
+                <span className="login-back-button-icon" aria-hidden="true">
+                  →
+                </span>
               </button>
             </div>
           </form>

--- a/web/src/styles/ForgotPasswordPage.css
+++ b/web/src/styles/ForgotPasswordPage.css
@@ -88,30 +88,51 @@
 
 .login-hero-back-button {
   align-self: flex-start;
+}
+
+.login-hero-back-button,
+.login-form-back-button {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 22px;
+  gap: 10px;
+  padding: 14px 24px;
   border-radius: 999px;
-  border: 2px solid rgba(255, 255, 255, 0.75);
-  background: transparent;
-  color: #ffffff;
+  border: none;
+  background: #ffd84f;
+  color: #333333;
   font-weight: 600;
   font-size: 1rem;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 12px 28px rgba(255, 216, 79, 0.3);
 }
 
 .login-hero-back-button:hover,
-.login-hero-back-button:focus-visible {
-  background: rgba(255, 255, 255, 0.15);
-  color: #ffffff;
+.login-hero-back-button:focus-visible,
+.login-form-back-button:hover,
+.login-form-back-button:focus-visible {
+  background: #ffcc33;
+  box-shadow: 0 16px 34px rgba(255, 204, 51, 0.35);
   transform: translateY(-1px);
   outline: none;
 }
 
-.login-hero-back-button:focus-visible {
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.4);
+.login-hero-back-button:focus-visible,
+.login-form-back-button:focus-visible {
+  box-shadow: 0 0 0 3px rgba(255, 204, 51, 0.45), 0 16px 34px rgba(255, 204, 51, 0.35);
+}
+
+.login-back-button-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: transform 0.2s ease;
+}
+
+.login-hero-back-button:hover .login-back-button-icon,
+.login-hero-back-button:focus-visible .login-back-button-icon,
+.login-form-back-button:hover .login-back-button-icon,
+.login-form-back-button:focus-visible .login-back-button-icon {
+  transform: translateX(2px);
 }
 
 .login-page--forgot .login-card {
@@ -177,33 +198,6 @@
   display: flex;
   justify-content: flex-start;
   margin-top: 8px;
-}
-
-.login-form-back-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 18px;
-  border-radius: 999px;
-  border: 1px solid #dfe5db;
-  background: transparent;
-  color: #2b2b2b;
-  font-weight: 600;
-  font-size: 0.95rem;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-.login-form-back-button:hover,
-.login-form-back-button:focus-visible {
-  background: rgba(87, 170, 39, 0.1);
-  border-color: rgba(87, 170, 39, 0.35);
-  color: #2b2b2b;
-  outline: none;
-}
-
-.login-form-back-button:focus-visible {
-  box-shadow: 0 0 0 3px rgba(87, 170, 39, 0.25);
 }
 
 .login-feedback {


### PR DESCRIPTION
## Summary
- update the forgot password "Zpět na přihlášení" buttons to match the homepage call-to-action styling
- add shared hover, focus, and icon transitions for the back buttons on the forgot password screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ec0e247b5c8326b4f5eec9ea62adce