### PR TITLE
Widen patrol loading manual entry layout

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1292,6 +1292,12 @@ textarea {
   gap: 16px;
   align-items: flex-start;
   flex-wrap: wrap;
+  width: 100%;
+}
+
+.manual-entry .patrol-code-input {
+  flex: 1 1 360px;
+  max-width: 560px;
 }
 
 .manual-entry button {
@@ -1300,6 +1306,10 @@ textarea {
 
 .manual-entry input {
   min-width: 200px;
+}
+
+.patrol-code-input__wheel-group {
+  width: 100%;
 }
 
 .scanner-preview {


### PR DESCRIPTION
## Summary
- allow the manual patrol entry section to stretch across the card
- expand the patrol code input so the picker can render wider
- ensure the wheel group spans the available width for better readability

## Testing
- npm test -- --run *(fails: vitest cannot resolve react-mobile-picker)*

------
https://chatgpt.com/codex/tasks/task_e_68f9e7e77ff083268af61a6fe2e49679